### PR TITLE
docs: fix setup documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@
 
 - [pnpm](https://pnpm.io/)
 - iOS simulator or Android emulator
-  - See [Expo documentation on setting up a development environment](https://docs.expo.dev/get-started/set-up-your-environment/?platform=ios&device=simulated&mode=development-build)
+  - See [Expo documentation on setting up a development environment](https://docs.expo.dev/get-started/set-up-your-environment/?platform=ios&device=simulated&mode=development-build&buildEnv=local)
 
 ### Installation
 


### PR DESCRIPTION
Updated Expo documentation link to include local build environment parameter so that EAS is turned off by default when you click the link.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/zZJDTogQbjQWXEHwCYBl/c5b7ee85-f028-4c2e-abe8-db6b41d6e519.png)

