### PR TITLE
feat: add user card and mock friends list

### DIFF
--- a/src/app/(tabs)/friends.tsx
+++ b/src/app/(tabs)/friends.tsx
@@ -2,7 +2,26 @@ import { router } from 'expo-router';
 import { UserPlus } from 'lucide-react-native';
 import React from 'react';
 
+import { type UserIDT } from '@/api';
+import UserCard, { type CompleteUserT } from '@/components/user-card';
 import { Header, ScreenContainer } from '@/ui';
+
+const mockFriends: CompleteUserT[] = [
+  {
+    id: '1' as UserIDT,
+    displayName: 'John Doe',
+    username: 'john_doe',
+    createdAt: new Date(),
+    picture: 'https://randomuser.me/api/portraits/men/1.jpg',
+  },
+  {
+    id: '2' as UserIDT,
+    displayName: 'Jane Doe',
+    username: 'jane_doe',
+    createdAt: new Date(),
+    picture: 'https://randomuser.me/api/portraits/women/3.jpg',
+  },
+];
 
 export default function Friends() {
   return (
@@ -17,6 +36,9 @@ export default function Friends() {
           },
         }}
       />
+      {mockFriends.map((friend) => (
+        <UserCard key={friend.id} data={friend} />
+      ))}
     </ScreenContainer>
   );
 }

--- a/src/components/user-card.tsx
+++ b/src/components/user-card.tsx
@@ -1,0 +1,43 @@
+import { Link } from 'expo-router';
+
+import { type UserIDT, type UserT } from '@/api';
+import { Image, Pressable, Text, View } from '@/ui';
+
+export type CompleteUserT = {
+  id: UserIDT;
+  picture: string;
+} & UserT;
+
+export default function UserCard({ data }: { data: CompleteUserT }) {
+  return (
+    <Link
+      push
+      href={{
+        pathname: '/friends/[id]',
+        params: {
+          id: data.id,
+          theirUserId: data.id,
+        },
+      }}
+      asChild
+    >
+      <Pressable className="my-1 flex flex-row gap-2 rounded-3xl border border-stone-200 bg-white px-4 py-[10px] dark:border-stone-700 dark:bg-transparent">
+        <Image
+          source={data.picture}
+          alt="Profile Picture"
+          className="rounded-full"
+          style={{
+            height: 40,
+            width: 40,
+          }}
+        />
+        <View className="flex flex-col">
+          <Text className="text-base font-semibold">{data.displayName}</Text>
+          <Text className="text-xs font-medium text-stone-400 dark:text-stone-400">
+            @{data.username}
+          </Text>
+        </View>
+      </Pressable>
+    </Link>
+  );
+}

--- a/src/ui/header.tsx
+++ b/src/ui/header.tsx
@@ -24,7 +24,7 @@ type Props = {
 };
 export const Header = ({ leftButton, title, rightButton }: Props) => {
   return (
-    <View className="flex h-8 flex-row items-center justify-between">
+    <View className="mb-4 flex h-8 flex-row items-center justify-between">
       {leftButton === 'back' ? (
         <BackButton />
       ) : leftButton === 'cancel' ? (


### PR DESCRIPTION
### TL;DR
Added a new UserCard component and implemented the friends list UI with mock data.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/zZJDTogQbjQWXEHwCYBl/33f0db5e-a78b-4e48-836e-584ac51aff39.png)

### Important

@AnkushSarkar10 we need to think about how the types should work. The `id` field is not included in `UserT`, and now that we are using Firebase Storage for pfps, the picture isn't included either. For now, I just made a new type in `user-card.tsx`, but we should figure out how we want to address this.

### What changed?
- Created a new UserCard component for displaying user information
- Added mock friend data to demonstrate the friends list
- Implemented friend list rendering in the friends tab
- Added margin bottom to the header component for better spacing
- Created navigation link to individual friend profiles

### How to test?
1. Navigate to the Friends tab
2. Verify that mock friends are displayed with their profile pictures and usernames
3. Confirm that tapping a friend card navigates to their profile
4. Check that the header spacing looks correct
5. Verify dark/light mode styling of the friend cards