### PR TITLE
feat: add user profile view and components

### DIFF
--- a/src/app/friends/[id].tsx
+++ b/src/app/friends/[id].tsx
@@ -1,18 +1,28 @@
-import { useLocalSearchParams } from 'expo-router';
 import * as React from 'react';
 
-import { Header, ScreenContainer, Text } from '@/ui';
+import { type UserIDT } from '@/api';
+import Profile from '@/components/profile';
+import { type CompleteUserT } from '@/components/user-card';
+import { Header, ScreenContainer } from '@/ui';
+
+const mockUser: CompleteUserT = {
+  id: '1' as UserIDT,
+  displayName: 'John Doe',
+  username: 'john_doe',
+  createdAt: new Date(),
+  picture: 'https://randomuser.me/api/portraits/men/1.jpg',
+};
 
 export default function ViewProfile() {
   // id automatically passed in from the route
-  const { id } = useLocalSearchParams<{
-    id: string;
-  }>();
+  // const { id } = useLocalSearchParams<{
+  //   id: string;
+  // }>();
 
   return (
-    <ScreenContainer className="flex-1">
+    <ScreenContainer>
       <Header leftButton="back" />
-      <Text className="text-base">{id}</Text>
+      <Profile data={mockUser} isFriend={true} />
     </ScreenContainer>
   );
 }

--- a/src/components/profile.tsx
+++ b/src/components/profile.tsx
@@ -1,0 +1,65 @@
+import { Trash2Icon, UserPlus } from 'lucide-react-native';
+import * as React from 'react';
+
+import { type CompleteUserT } from '@/components/user-card';
+import { Button, Image, Text, View } from '@/ui';
+
+export default function Profile({
+  data,
+  isFriend,
+}: {
+  data: CompleteUserT;
+  isFriend: boolean;
+}) {
+  return (
+    <View className="flex flex-col items-center gap-4">
+      <View className="flex flex-col items-center gap-2">
+        <View className="flex flex-col">
+          <Text className="text-center text-lg font-semibold">
+            {data.displayName}
+          </Text>
+          <Text className="text-center text-sm font-medium text-stone-400 dark:text-stone-400">
+            @{data.username}
+          </Text>
+        </View>
+        <Image
+          source={data.picture}
+          alt="Profile Picture"
+          className="rounded-full"
+          style={{
+            height: 128,
+            width: 128,
+          }}
+        />
+        <Text className="text-center text-sm font-medium text-stone-400 dark:text-stone-400">
+          Joined{' '}
+          {data.createdAt.toLocaleDateString('en-US', {
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric',
+          })}
+        </Text>
+      </View>
+      {isFriend ? (
+        <Button
+          icon={Trash2Icon}
+          label="Remove Friend"
+          variant="destructive"
+          className="w-full"
+          onPress={() => {
+            alert('Remove friend');
+          }}
+        />
+      ) : (
+        <Button
+          icon={UserPlus}
+          label="Add Friend"
+          className="w-full"
+          onPress={() => {
+            alert('Add friend');
+          }}
+        />
+      )}
+    </View>
+  );
+}

--- a/src/ui/button.tsx
+++ b/src/ui/button.tsx
@@ -33,8 +33,9 @@ const button = tv({
         indicator: 'text-black dark:text-neutral-100',
       },
       destructive: {
-        container: 'bg-red-600',
-        label: 'text-white',
+        container:
+          'border border-red-200 bg-white dark:border-red-500 dark:bg-transparent',
+        label: 'font-medium text-red-500',
         indicator: 'text-white',
       },
       ghost: {


### PR DESCRIPTION
### TL;DR
Added a new Profile component and updated the friends profile view with mock data

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/zZJDTogQbjQWXEHwCYBl/7ca2800f-2895-41ba-b0e4-20b7c5223156.png)

It shows a Remove Friend button if you're friends with them already, and an Add Friend button if not.

### What changed?
- Created a new Profile component with user information display and friend management
- Updated the friends profile view to use mock data and the new Profile component
- Modified the destructive button variant styling to use a softer, outlined appearance
- Replaced the basic ID display with a complete user profile interface

### How to test?
1. Navigate to a friend's profile page
2. Verify the profile displays mock user data (John Doe)
3. Confirm the profile picture, username, join date, and friend management buttons are visible
4. Check that the "Remove Friend" button shows the new outlined destructive styling
5. Verify the layout is centered and properly spaced