### PR TITLE
feat: data fetching improvements

### DIFF
--- a/src/api/common/add-test-delay.ts
+++ b/src/api/common/add-test-delay.ts
@@ -1,4 +1,4 @@
 export const addTestDelay = async <T>(value: T): Promise<T> => {
-  await new Promise((resolve) => setTimeout(resolve, 300));
+  await new Promise((resolve) => setTimeout(resolve, 400));
   return value;
 };

--- a/src/api/habits/augment-participant-pictures.tsx
+++ b/src/api/habits/augment-participant-pictures.tsx
@@ -1,0 +1,47 @@
+import { addTestDelay } from '../common';
+import { type UserIdT } from '../users';
+import { mockPictures } from '../users/mock-users';
+import { type HabitT, type HabitWithParticipantPicturesT } from './types';
+
+export const augmentParticipantsWithPicturesForAllHabits = async (
+  habits: HabitT[],
+) => {
+  const habitsWithUserPictures: HabitWithParticipantPicturesT[] = habits.map(
+    (habit) => ({
+      ...habit,
+      participants: Object.fromEntries(
+        Object.entries(habit.participants).map(([id, participant]) => {
+          try {
+            const picture = mockPictures[id as UserIdT];
+            return [
+              id,
+              {
+                ...participant,
+                picture: {
+                  url: picture,
+                  isPending: false,
+                  isError: false,
+                  error: null,
+                },
+              },
+            ];
+          } catch (error) {
+            return [
+              id,
+              {
+                ...participant,
+                picture: {
+                  url: null,
+                  isPending: false,
+                  isError: true,
+                  error: error as string,
+                },
+              },
+            ];
+          }
+        }),
+      ),
+    }),
+  );
+  return addTestDelay(habitsWithUserPictures);
+};

--- a/src/api/habits/mock-habits.tsx
+++ b/src/api/habits/mock-habits.tsx
@@ -1,7 +1,12 @@
-import { type HabitIdT, type HabitWithCompletionsT, type UserIdT } from '@/api';
+import {
+  type AllCompletionsT,
+  type HabitIdT,
+  type HabitWithParticipantsT,
+  type UserIdT,
+} from '@/api';
 import { habitColors } from '@/ui/colors';
 
-export const mockHabits: HabitWithCompletionsT[] = [
+export const mockHabits: HabitWithParticipantsT[] = [
   {
     id: '1' as HabitIdT,
     color: habitColors.orange,
@@ -14,19 +19,11 @@ export const mockHabits: HabitWithCompletionsT[] = [
     },
     icon: '💧',
     participants: {
-      user1: {
+      ['1' as UserIdT]: {
         displayName: 'John Doe',
         username: 'johndoe',
         mostRecentCompletionDate: new Date('2024-01-15'),
         isOwner: true,
-      },
-    },
-    participantCompletions: {
-      ['1' as UserIdT]: {
-        completions: {
-          '2024-12-06': 1,
-          '2024-12-05': 2,
-        },
       },
     },
   },
@@ -42,19 +39,11 @@ export const mockHabits: HabitWithCompletionsT[] = [
     },
     icon: '🏃',
     participants: {
-      user2: {
+      ['2' as UserIdT]: {
         displayName: 'Jane Smith',
         username: 'janesmith',
         mostRecentCompletionDate: new Date('2024-01-15'),
         isOwner: true,
-      },
-    },
-    participantCompletions: {
-      ['1' as UserIdT]: {
-        completions: {
-          '2024-12-06': 1,
-          '2024-12-05': 2,
-        },
       },
     },
   },
@@ -70,20 +59,42 @@ export const mockHabits: HabitWithCompletionsT[] = [
     },
     icon: '📚',
     participants: {
-      user3: {
+      ['3' as UserIdT]: {
         displayName: 'Alex Chen',
         username: 'alexchen',
         mostRecentCompletionDate: new Date('2024-01-15'),
         isOwner: true,
       },
     },
-    participantCompletions: {
-      ['1' as UserIdT]: {
-        completions: {
-          '2024-12-06': 1,
-          '2024-12-05': 1,
-        },
+  },
+];
+
+export const mockHabitCompletions: Record<HabitIdT, AllCompletionsT> = {
+  ['1' as HabitIdT]: {
+    ['1' as UserIdT]: {
+      completions: {
+        '2024-12-04': 0,
+        '2024-12-05': 1,
+        '2024-12-06': 1,
       },
     },
   },
-];
+  ['2' as HabitIdT]: {
+    ['1' as UserIdT]: {
+      completions: {
+        '2024-12-04': 1,
+        '2024-12-05': 0,
+        '2024-12-06': 1,
+      },
+    },
+  },
+  ['3' as HabitIdT]: {
+    ['1' as UserIdT]: {
+      completions: {
+        '2024-12-04': 0,
+        '2024-12-05': 0,
+        '2024-12-06': 1,
+      },
+    },
+  },
+};

--- a/src/api/habits/types.ts
+++ b/src/api/habits/types.ts
@@ -1,17 +1,49 @@
 import { z } from 'zod';
 
 import { colorSchema } from '../colors-schemas';
-import { UserIdSchema, type UserIdT } from '../users/types';
+import { UserIdSchema, type UserIdT, userPictureSchema } from '../users/types';
 
 export type HabitIdT = string & { readonly __brand: unique symbol };
-
 export const HabitIdSchema = z.coerce
   .string()
   .transform((val) => val as HabitIdT);
 
 export const habitCompletionPeriodSchema = z.enum(['daily', 'weekly']);
+export type HabitCompletionPeriodT = z.infer<
+  typeof habitCompletionPeriodSchema
+>;
 
-export const habitSchema = z.object({
+export const participantSchema = z.object({
+  displayName: z.string(),
+  username: z.string(),
+  mostRecentCompletionDate: z.date(),
+  isOwner: z.boolean().optional(),
+});
+export type ParticipantT = z.infer<typeof participantSchema>;
+
+export const participantsSchema = z.record(
+  UserIdSchema,
+  z.object({
+    displayName: z.string(),
+    username: z.string(),
+    mostRecentCompletionDate: z.date(),
+    isOwner: z.boolean().optional(),
+  }),
+);
+export type ParticipantsT = Record<UserIdT, ParticipantT>;
+
+export const participantsWithPictureSchema = z.record(
+  UserIdSchema,
+  participantSchema.extend({
+    picture: userPictureSchema,
+  }),
+);
+export type ParticipantsWithPictureT = Record<
+  UserIdT,
+  ParticipantT & { picture: string }
+>;
+
+export const habitInfoSchema = z.object({
   color: colorSchema,
   createdAt: z.date(),
   description: z.string(),
@@ -21,34 +53,57 @@ export const habitSchema = z.object({
     completionsPerPeriod: z.number(),
   }),
   icon: z.string(),
-  participants: z.record(
-    z.string(),
-    z.object({
-      displayName: z.string(),
-      username: z.string(),
-      mostRecentCompletionDate: z.date(),
-      isOwner: z.boolean().optional(),
-    }),
-  ),
 });
+export type HabitInfoT = z.infer<typeof habitInfoSchema>;
+
+export const habitInfoWithIdSchema = habitInfoSchema.extend({
+  id: HabitIdSchema,
+});
+export type HabitInfoWithIdT = z.infer<typeof habitInfoWithIdSchema>;
+
+export const habitSchema = habitInfoWithIdSchema.extend({
+  participants: participantsWithPictureSchema,
+});
+export type HabitT = z.infer<typeof habitSchema>;
+
+export const habitWithParticipantsSchema = habitInfoWithIdSchema.extend({
+  participants: participantsSchema,
+});
+export type HabitWithParticipantsT = z.infer<
+  typeof habitWithParticipantsSchema
+>;
+
+export const habitWithParticipantPicturesSchema = habitInfoWithIdSchema.extend({
+  participants: participantsWithPictureSchema,
+});
+export type HabitWithParticipantPicturesT = z.infer<
+  typeof habitWithParticipantPicturesSchema
+>;
 
 export const participantCompletionsSchema = z.object({
   completions: z.record(z.string(), z.number()), // { date: numberOfCompletions }
 });
-
-export const allCompletionsSchema = z.object({
-  userId: z.record(UserIdSchema, participantCompletionsSchema), // { userId: participantCompletions }
-});
-
-export type HabitCompletionPeriodT = z.infer<
-  typeof habitCompletionPeriodSchema
->;
-export type HabitT = z.infer<typeof habitSchema> & { id: HabitIdT };
 export type ParticipantCompletionsT = z.infer<
   typeof participantCompletionsSchema
 >;
-export type AllCompletionsT = Record<UserIdT, ParticipantCompletionsT>;
-// when inferring the type it converts the userId to a string, so define manually
-export type HabitWithCompletionsT = HabitT & {
-  participantCompletions: AllCompletionsT;
-};
+
+export const allCompletionsSchema = z.record(
+  UserIdSchema,
+  participantCompletionsSchema,
+);
+export type AllCompletionsT = z.infer<typeof allCompletionsSchema>;
+
+export const completeHabit = habitWithParticipantPicturesSchema.extend({
+  ...participantCompletionsSchema.shape,
+});
+export type HabitWithCompletionsT = z.infer<typeof completeHabit>;
+
+export const habitCompletionWithDateInfoSchema = z.object({
+  date: z.string(),
+  numberOfCompletions: z.number(),
+  dayOfTheMonth: z.number(),
+  dayOfTheWeek: z.string(),
+});
+export type HabitCompletionWithDateInfoT = z.infer<
+  typeof habitCompletionWithDateInfoSchema
+>;

--- a/src/api/habits/use-habit-completions.tsx
+++ b/src/api/habits/use-habit-completions.tsx
@@ -1,0 +1,63 @@
+import { createQuery } from 'react-query-kit';
+
+import { addTestDelay } from '../common';
+import { type UserIdT } from '../users';
+import { mockHabitCompletions } from './mock-habits';
+import {
+  type HabitCompletionWithDateInfoT,
+  type HabitIdT,
+  type ParticipantCompletionsT,
+} from './types';
+
+type Response = HabitCompletionWithDateInfoT[];
+type Variables = {
+  habitId: HabitIdT;
+  userId: UserIdT;
+};
+
+export const useHabitCompletions = createQuery<Response, Variables, Error>({
+  queryKey: ['habits-completions'],
+  fetcher: async (variables) => {
+    const completions = mockHabitCompletions[variables.habitId];
+    if (!completions) {
+      throw new Error('Habit not found');
+    }
+    const participantCompletions = completions[variables.userId];
+    if (!participantCompletions) {
+      throw new Error('Participant not found');
+    }
+
+    const structuredCompletions: HabitCompletionWithDateInfoT[] =
+      getStructuredCompletionData(participantCompletions, 7);
+
+    return await addTestDelay(structuredCompletions);
+  },
+});
+
+function getStructuredCompletionData(
+  completionData: ParticipantCompletionsT,
+  numDays: number,
+): HabitCompletionWithDateInfoT[] {
+  const structuredCompletionData: HabitCompletionWithDateInfoT[] = [];
+
+  let currentDate = new Date();
+  // go back to the first day we want to display
+  currentDate.setDate(currentDate.getDate() - numDays + 1);
+  // loop through each day and add the completion data for that day to the structured data
+  for (let i = 0; i < numDays; i++) {
+    // if there is no completion data for the current date, default to 0 (no completions that day)
+    structuredCompletionData.push({
+      numberOfCompletions:
+        completionData?.completions?.[
+          currentDate.toLocaleDateString('en-CA')
+        ] ?? 0,
+      dayOfTheMonth: currentDate.getDate(),
+      dayOfTheWeek: currentDate.toLocaleString('en-US', { weekday: 'short' }),
+      date: currentDate.toLocaleDateString('en-CA'),
+    });
+    // move current date ahead 1 day
+    currentDate.setDate(currentDate.getDate() + 1);
+  }
+
+  return structuredCompletionData;
+}

--- a/src/api/habits/use-habits.tsx
+++ b/src/api/habits/use-habits.tsx
@@ -1,15 +1,47 @@
 import { createQuery } from 'react-query-kit';
 
-import { addTestDelay } from '../common';
+import { addTestDelay, queryClient } from '../common';
+import { loadingPicture } from '../users';
+import { augmentParticipantsWithPicturesForAllHabits } from './augment-participant-pictures';
 import { mockHabits } from './mock-habits';
-import { type HabitWithCompletionsT } from './types';
+import { type HabitWithParticipantPicturesT } from './types';
 
-type Response = HabitWithCompletionsT[];
+type Response = HabitWithParticipantPicturesT[];
 type Variables = void;
 
 export const useHabits = createQuery<Response, Variables, Error>({
   queryKey: ['habits'],
   fetcher: async () => {
-    return addTestDelay(mockHabits);
+    const habits = await addTestDelay(mockHabits);
+    const habitsWithUserPictures: HabitWithParticipantPicturesT[] = habits.map(
+      (habit) => ({
+        ...habit,
+        participants: Object.fromEntries(
+          Object.entries(habit.participants).map(([id, participant]) => {
+            if (!participant)
+              throw new Error('Participant not found for habit ' + habit.title);
+
+            return [
+              id,
+              {
+                displayName: participant.displayName,
+                username: participant.username,
+                mostRecentCompletionDate: participant.mostRecentCompletionDate,
+                picture: loadingPicture,
+                isOwner: participant?.isOwner ?? false,
+              },
+            ];
+          }),
+        ),
+      }),
+    );
+
+    augmentParticipantsWithPicturesForAllHabits(habitsWithUserPictures).then(
+      (augmentedHabits) => {
+        queryClient.setQueryData(['habits'], augmentedHabits);
+      },
+    );
+
+    return habitsWithUserPictures;
   },
 });

--- a/src/api/users/augment-user-pictures.tsx
+++ b/src/api/users/augment-user-pictures.tsx
@@ -1,0 +1,41 @@
+import { showMessage } from 'react-native-flash-message';
+
+import { addTestDelay } from '../common';
+import { mockPictures } from './mock-users';
+import { type CompleteUserT } from './types';
+
+export const augmentUsersWithPictures = async (users: CompleteUserT[]) => {
+  const friendsWithPictures: CompleteUserT[] = users.map((user) => {
+    try {
+      const picture = mockPictures[user.id];
+      if (!picture) {
+        throw new Error('Picture not found');
+      }
+      return {
+        ...user,
+        picture: {
+          url: picture,
+          isPending: false,
+          isError: false,
+          error: null,
+        },
+      };
+    } catch (error) {
+      console.log('Error fetching user picture');
+      showMessage({
+        message: 'Error fetching image(s)',
+        type: 'danger',
+      });
+      return {
+        ...user,
+        picture: {
+          url: null,
+          isPending: false,
+          isError: true,
+          error: error as string,
+        },
+      };
+    }
+  });
+  return addTestDelay(friendsWithPictures);
+};

--- a/src/api/users/mock-users.tsx
+++ b/src/api/users/mock-users.tsx
@@ -1,0 +1,47 @@
+import { type UserIdT, type UserWithFriendStatusT } from './types';
+
+export const mockUsers: UserWithFriendStatusT[] = [
+  {
+    id: '1' as UserIdT,
+    displayName: 'John Doe',
+    username: 'john_doe',
+    createdAt: new Date(),
+    isFriend: true,
+  },
+  {
+    id: '2' as UserIdT,
+    displayName: 'Jane Doe',
+    username: 'jane_doe',
+    createdAt: new Date(),
+    isFriend: true,
+  },
+  {
+    id: '3' as UserIdT,
+    displayName: 'Apple Smith',
+    username: 'apple',
+    createdAt: new Date(),
+    isFriend: false,
+  },
+  {
+    id: '4' as UserIdT,
+    displayName: 'Bob Johnson',
+    username: 'bob_johnson',
+    createdAt: new Date(),
+    isFriend: true,
+  },
+  {
+    id: '5' as UserIdT,
+    displayName: 'Lorem Ipsum',
+    username: 'lorem_ipsum',
+    createdAt: new Date(),
+    isFriend: false,
+  },
+];
+
+export const mockPictures: Record<UserIdT, string> = {
+  ['1' as UserIdT]: 'https://randomuser.me/api/portraits/men/1.jpg',
+  ['2' as UserIdT]: 'https://randomuser.me/api/portraits/women/3.jpg',
+  ['3' as UserIdT]: 'https://randomuser.me/api/portraits/women/4.jpg',
+  ['4' as UserIdT]: 'https://randomuser.me/api/portraits/men/5.jpg',
+  ['5' as UserIdT]: 'https://randomuser.me/api/portraits/men/6.jpg',
+};

--- a/src/api/users/types.ts
+++ b/src/api/users/types.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod';
 
 export type UserIdT = string & { readonly __brand: unique symbol };
-export type FriendshipIdT = string & { readonly __brand: unique symbol };
-
 export const UserIdSchema = z.coerce
   .string()
   .transform((val) => val as UserIdT);
+
+export type FriendshipIdT = string & { readonly __brand: unique symbol };
 export const FriendshipIdSchema = z.coerce
   .string()
   .transform((val) => val as FriendshipIdT);
@@ -15,24 +15,62 @@ export const userSchema = z.object({
   displayName: z.string(),
   username: z.string(),
 });
+export type UserT = z.infer<typeof userSchema>;
+
+export const userWithIdSchema = userSchema.extend({
+  id: UserIdSchema,
+});
+export type UserWithIdT = z.infer<typeof userWithIdSchema>;
+
+export const friendStatusSchema = z.object({
+  isFriend: z.boolean(),
+});
+export type FriendStatusT = z.infer<typeof friendStatusSchema>;
+
+export const userWithFriendStatusSchema = userWithIdSchema.extend({
+  ...friendStatusSchema.shape,
+});
+export type UserWithFriendStatusT = z.infer<typeof userWithFriendStatusSchema>;
+
+export const userPictureSchema = z.union([
+  // fetched valid image
+  z.object({
+    url: z.string(),
+    isPending: z.literal(false),
+    isError: z.literal(false),
+    error: z.literal(null),
+  }),
+  // we are fetching the image still
+  z.object({
+    url: z.literal(null),
+    isPending: z.literal(true),
+    isError: z.literal(false),
+    error: z.literal(null),
+  }),
+  // we got a response but it was an error
+  z.object({
+    url: z.literal(null),
+    isPending: z.literal(false),
+    isError: z.literal(true),
+    error: z.string(),
+  }),
+]);
+export type UserPictureT = z.infer<typeof userPictureSchema>;
+export const loadingPicture: UserPictureT = {
+  url: null,
+  isPending: true,
+  isError: false,
+  error: null,
+};
+
+export const completeUserSchema = userWithFriendStatusSchema.extend({
+  picture: userPictureSchema,
+});
+export type CompleteUserT = z.infer<typeof completeUserSchema>;
 
 export const friendshipSchema = z.object({
   user1Id: UserIdSchema,
   user2Id: UserIdSchema,
   friendsSince: z.date(),
 });
-
-export type UserT = z.infer<typeof userSchema>;
-
 export type FriendshipT = z.infer<typeof friendshipSchema>;
-
-// TODO: figure out what to do about user types (then create zod schemas for them)
-export type CompleteUserT = {
-  id: UserIdT;
-  picture: string;
-} & UserT;
-export type CompleteUserWithFriendStatusT = {
-  id: UserIdT;
-  picture: string;
-  isFriend: boolean;
-} & UserT;

--- a/src/api/users/use-remove-friend.tsx
+++ b/src/api/users/use-remove-friend.tsx
@@ -1,10 +1,10 @@
 import { createMutation } from 'react-query-kit';
 
 import { addTestDelay, queryClient } from '../common';
-import { type CompleteUserWithFriendStatusT, type UserIdT } from './types';
+import { type CompleteUserT, loadingPicture, type UserIdT } from './types';
 
 type Variables = { id: UserIdT };
-type Response = CompleteUserWithFriendStatusT;
+type Response = CompleteUserT;
 
 export const useRemoveFriend = createMutation<Response, Variables, Error>({
   mutationFn: async (variables) => {
@@ -13,7 +13,7 @@ export const useRemoveFriend = createMutation<Response, Variables, Error>({
       displayName: 'Old Friend',
       username: 'old_friend',
       createdAt: new Date(),
-      picture: 'https://randomuser.me/api/portraits/men/1.jpg',
+      picture: loadingPicture,
       isFriend: false,
     });
     return friend;

--- a/src/api/users/use-send-friend-request.tsx
+++ b/src/api/users/use-send-friend-request.tsx
@@ -1,10 +1,10 @@
 import { createMutation } from 'react-query-kit';
 
 import { addTestDelay, queryClient } from '../common';
-import { type CompleteUserWithFriendStatusT, type UserIdT } from './types';
+import { type CompleteUserT, loadingPicture, type UserIdT } from './types';
 
 type Variables = { id: UserIdT };
-type Response = CompleteUserWithFriendStatusT;
+type Response = CompleteUserT;
 
 export const useSendFriendRequest = createMutation<Response, Variables, Error>({
   mutationFn: async (variables) => {
@@ -13,7 +13,7 @@ export const useSendFriendRequest = createMutation<Response, Variables, Error>({
       displayName: 'New Friend',
       username: 'new_friend',
       createdAt: new Date(),
-      picture: 'https://randomuser.me/api/portraits/men/1.jpg',
+      picture: loadingPicture,
       isFriend: true,
     });
     return friend;

--- a/src/app/(tabs)/index.tsx
+++ b/src/app/(tabs)/index.tsx
@@ -35,7 +35,7 @@ export default function Habits() {
           ) : isError ? (
             <ErrorMessage error={error} refetch={refetch} />
           ) : (
-            data.map((habit) => <HabitCard key={habit.id} data={habit} />)
+            data.map((habit) => <HabitCard key={habit.id} habit={habit} />)
           )}
         </View>
       </ScrollView>

--- a/src/components/picture.tsx
+++ b/src/components/picture.tsx
@@ -1,0 +1,36 @@
+import { TriangleAlertIcon } from 'lucide-react-native';
+
+import { type UserPictureT } from '@/api';
+import { Image, View } from '@/ui';
+
+interface PictureProps {
+  picture: UserPictureT;
+  size: 128 | 40;
+}
+export default function UserPicture({ picture, size }: PictureProps) {
+  return (
+    <View
+      className={`${picture.isPending ? 'animate-pulse' : 'animate-none'} rounded-full bg-stone-200 dark:bg-stone-700`}
+      style={{
+        height: size,
+        width: size,
+      }}
+    >
+      {picture.isPending ? (
+        <></>
+      ) : picture.isError ? (
+        <TriangleAlertIcon className="m-auto h-8 w-8 text-red-500" />
+      ) : (
+        <Image
+          source={picture.url}
+          alt="Profile Picture"
+          className="rounded-full"
+          style={{
+            height: size,
+            width: size,
+          }}
+        />
+      )}
+    </View>
+  );
+}

--- a/src/components/profile.tsx
+++ b/src/components/profile.tsx
@@ -1,15 +1,13 @@
 import { Trash2Icon, UserPlus } from 'lucide-react-native';
 import * as React from 'react';
 
-import { type CompleteUserWithFriendStatusT } from '@/api';
+import { type CompleteUserT } from '@/api';
 import { useFriendManagement } from '@/core';
-import { Button, Image, Text, View } from '@/ui';
+import { Button, Text, View } from '@/ui';
 
-export default function Profile({
-  data,
-}: {
-  data: CompleteUserWithFriendStatusT;
-}) {
+import UserPicture from './picture';
+
+export default function Profile({ data }: { data: CompleteUserT }) {
   const {
     isFriend,
     handleSendFriendRequest,
@@ -29,15 +27,8 @@ export default function Profile({
             @{data.username}
           </Text>
         </View>
-        <Image
-          source={data.picture}
-          alt="Profile Picture"
-          className="rounded-full"
-          style={{
-            height: 128,
-            width: 128,
-          }}
-        />
+        <UserPicture picture={data.picture} size={128} />
+
         <Text className="text-center text-sm font-medium text-stone-400 dark:text-stone-400">
           Joined{' '}
           {data.createdAt.toLocaleDateString('en-US', {

--- a/src/components/user-card.tsx
+++ b/src/components/user-card.tsx
@@ -1,7 +1,9 @@
 import { Link } from 'expo-router';
 
 import { type CompleteUserT } from '@/api';
-import { Image, Pressable, Text, View } from '@/ui';
+import { Pressable, Text, View } from '@/ui';
+
+import UserPicture from './picture';
 
 export default function UserCard({ data }: { data: CompleteUserT }) {
   return (
@@ -17,15 +19,7 @@ export default function UserCard({ data }: { data: CompleteUserT }) {
       asChild
     >
       <Pressable className="my-1 flex flex-row gap-2 rounded-3xl border border-stone-200 bg-white px-4 py-[10px] dark:border-stone-700 dark:bg-transparent">
-        <Image
-          source={data.picture}
-          alt="Profile Picture"
-          className="rounded-full"
-          style={{
-            height: 40,
-            width: 40,
-          }}
-        />
+        <UserPicture picture={data.picture} size={40} />
         <View className="flex flex-col">
           <Text className="text-base font-semibold">{data.displayName}</Text>
           <Text className="text-xs font-medium text-stone-400 dark:text-stone-400">

--- a/src/ui/loading-spinner.tsx
+++ b/src/ui/loading-spinner.tsx
@@ -1,9 +1,13 @@
 import { ActivityIndicator, View } from 'react-native';
 
-export const LoadingSpinner = () => {
+export const LoadingSpinner = ({
+  size = 'small',
+}: {
+  size?: 'small' | 'large';
+}) => {
   return (
     <View className="m-2 h-fit w-fit flex-1 items-center justify-center">
-      <ActivityIndicator size="large" />
+      <ActivityIndicator size={size} />
     </View>
   );
 };


### PR DESCRIPTION
### TL;DR

Refactored habit and user data structures to support loading states for user pictures and separated habit completion data from habit metadata.

This sets everything up for how Firebase is structured. Profile pictures and habit completions are fetched separately.

The queries use a trick where they return data as soon as they have it, then automatically augment the data and update once the new information loads.

For example, your friends list is returned right away with the images in a loading state. It then fetches the images in the background and once they load in, it automatically updates the images with the urls.

<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/zZJDTogQbjQWXEHwCYBl/4dde9c5f-b96f-4671-9ad3-1e5b0c2479f6.mov">Screen Recording 2024-12-07 at 9.25.53 PM.mov</video>

### What changed?

- Added loading states for user profile pictures with proper error handling
- Separated habit completion data from habit metadata into its own structure
- Created new components for displaying user pictures with loading/error states
- Added new types and schemas to support the restructured data
- Implemented picture loading with loading indicators and error states
- Added new API endpoints for fetching habit completions separately

### How to test?

1. Navigate to the habits list and verify loading states for user pictures
2. Check habit completion data displays correctly in the weekly view
3. Test error states by triggering network failures
4. Verify user profile pictures load properly in user cards and profiles
5. Confirm habit completion tracking still works as expected

### Why make this change?

This restructuring improves the user experience by providing immediate feedback during picture loading and separating concerns between habit metadata and completion data. It also makes the codebase more maintainable by properly typing the data structures and handling error cases explicitly.