### PR TITLE
fix: habit completion and confetti positioning

### DIFF
--- a/src/api/habits/mock-habits.tsx
+++ b/src/api/habits/mock-habits.tsx
@@ -98,3 +98,8 @@ export const mockHabitCompletions: Record<HabitIdT, AllCompletionsT> = {
     },
   },
 };
+export const setMockHabitCompletions = (
+  newCompletions: Record<HabitIdT, AllCompletionsT>,
+) => {
+  Object.assign(mockHabitCompletions, newCompletions);
+};

--- a/src/api/habits/use-press-habit-button.tsx
+++ b/src/api/habits/use-press-habit-button.tsx
@@ -2,7 +2,11 @@ import { createMutation } from 'react-query-kit';
 
 import { addTestDelay, queryClient } from '../common';
 import { type UserIdT } from '../users/types';
-import { mockHabitCompletions, mockHabits } from './mock-habits';
+import {
+  mockHabitCompletions,
+  mockHabits,
+  setMockHabitCompletions,
+} from './mock-habits';
 import { type AllCompletionsT, type HabitIdT } from './types';
 
 type Response = AllCompletionsT;
@@ -24,8 +28,11 @@ export const usePressHabitButton = createMutation<Response, Variables, Error>({
 
     const numCompletions = participantCompletions.completions[variables.date];
 
-    const newNumCompletions =
-      (numCompletions + 1) % (habit.goal.completionsPerPeriod + 1);
+    let newNumCompletions = 1;
+    if (numCompletions) {
+      newNumCompletions =
+        (numCompletions + 1) % (habit.goal.completionsPerPeriod + 1);
+    }
 
     const newCompletions = {
       ...participantCompletions,
@@ -35,7 +42,13 @@ export const usePressHabitButton = createMutation<Response, Variables, Error>({
       },
     };
 
-    mockHabitCompletions[variables.habitId][variables.userId] = newCompletions;
+    setMockHabitCompletions({
+      ...mockHabitCompletions,
+      [variables.habitId]: {
+        ...mockHabitCompletions[variables.habitId],
+        [variables.userId]: newCompletions,
+      },
+    });
 
     return await addTestDelay(mockHabits[habitIndex]);
   },

--- a/src/core/confetti.tsx
+++ b/src/core/confetti.tsx
@@ -45,7 +45,7 @@ export function ConfettiProvider({ children }: { children: React.ReactNode }) {
   return (
     <ConfettiContext.Provider value={{ playConfetti }}>
       {children}
-      <View className="absolute inset-0 scale-50">
+      <View className="container pointer-events-none absolute inset-0 scale-50">
         {confettiInstances.map(({ id, x, y }) => (
           <LottieView
             key={id}
@@ -58,7 +58,7 @@ export function ConfettiProvider({ children }: { children: React.ReactNode }) {
             style={{
               position: 'absolute',
               top: y * 2 - 80,
-              left: x * 2,
+              left: x * 2 - 212,
               width: size,
               height: size,
               zIndex: 1000,


### PR DESCRIPTION
### TL;DR
Fixed habit completion tracking and improved confetti animation positioning

### What changed?
- Added `setMockHabitCompletions` function to safely update mock habit completion data
- Fixed habit completion counter to properly initialize at 1 for new completions
- Adjusted confetti animation positioning and made it non-interactive
- Updated confetti container to prevent interference with underlying UI elements

### How to test?
1. Complete a habit for the first time - verify it starts at 1 completion
2. Complete habits multiple times - verify the counter increments correctly
3. Reach a habit goal - confirm confetti appears in the correct position
4. Verify you can still interact with UI elements when confetti is playing