### PR TITLE
feat: habit participant activity, reordering habits list, dropdown menus

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,11 @@
    ```
    pnpm start
    ```
-   Then instructions will appear for how to open your simulator/emulator. Alternatively, you can use `pnpm ios` or `pnpm android` directly.
+   Then instructions will appear for how to open your simulator/emulator. Alternatively, you can use `pnpm ios` or `pnpm android` directly. (You might need to use `pnpm ios` or `pnpm android` after installing packages for the first time.)
+
+### Common Issues
+
+- If some nativewind styles are just not applying sometimes, clear the cache using `pnpm start -c`.
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "react-native-web": "~0.19.12",
     "react-query-kit": "^3.3.0",
     "tailwind-variants": "^0.2.1",
+    "zeego": "^2.0.4",
     "zod": "^3.23.8",
     "zustand": "^4.5.5"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       tailwind-variants:
         specifier: ^0.2.1
         version: 0.2.1(tailwindcss@3.3.2)
+      zeego:
+        specifier: ^2.0.4
+        version: 2.0.4(@react-native-menu/menu@1.1.7(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react-native-ios-context-menu@2.5.3(expo@51.0.32(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(react-native-ios-utilities@4.5.1(expo@51.0.32(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
       zod:
         specifier: ^3.23.8
         version: 3.23.8
@@ -976,6 +979,9 @@ packages:
       '@tanstack/react-query': '*'
       expo: '*'
 
+  '@dominicstop/ts-event-emitter@1.1.0':
+    resolution: {integrity: sha512-CcxmJIvUb1vsFheuGGVSQf4KdPZC44XolpUT34+vlal+LyQoBUOn31pjFET5M9ctOxEpt8xa0M3/2M7uUiAoJw==}
+
   '@egjs/hammerjs@2.0.17':
     resolution: {integrity: sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==}
     engines: {node: '>=0.8.0'}
@@ -1084,6 +1090,21 @@ packages:
   '@expo/xcpretty@4.3.1':
     resolution: {integrity: sha512-sqXgo1SCv+j4VtYEwl/bukuOIBrVgx6euIoCat3Iyx5oeoXwEA2USCoeL0IPubflMxncA2INkqJ/Wr3NGrSgzw==}
     hasBin: true
+
+  '@floating-ui/core@1.6.8':
+    resolution: {integrity: sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA==}
+
+  '@floating-ui/dom@1.6.12':
+    resolution: {integrity: sha512-NP83c0HjokcGVEMeoStg317VD9W7eDlGK7457dMBANbKA6GJZdc7rjujdgqzTaz93jkGgc5P/jeWbaCHnMNc+w==}
+
+  '@floating-ui/react-dom@2.1.2':
+    resolution: {integrity: sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/utils@0.2.8':
+    resolution: {integrity: sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==}
 
   '@formatjs/ecma402-abstract@2.0.0':
     resolution: {integrity: sha512-rRqXOqdFmk7RYvj4khklyqzcfQl9vEL/usogncBHRZfZBDOwMGuSRNFl02fu5KGHXdbinju+YXyuR+Nk8xlr/g==}
@@ -1427,15 +1448,294 @@ packages:
     resolution: {integrity: sha512-c83qWb22rNRuB0UaVCI0uRPNRr8Z0FWnEIvT47jiHAmOIUHbBOg5XvV7pM5x+rKn9HRpjxquDbXYSXr3fAKFcw==}
     engines: {node: '>=12'}
 
+  '@radix-ui/primitive@1.1.0':
+    resolution: {integrity: sha512-4Z8dn6Upk0qk4P74xBhZ6Hd/w0mPEzOOLxy4xiPXOXqjF7jZS0VAKk7/x/H6FyY2zCkYJqePf1G5KmkmNJ4RBA==}
+
+  '@radix-ui/react-arrow@1.1.0':
+    resolution: {integrity: sha512-FmlW1rCg7hBpEBwFbjHwCW6AmWLQM6g/v0Sn8XbP9NvmSZ2San1FpQeyPtufzOMSIx7Y4dzjlHoifhp+7NkZhw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collection@1.1.0':
+    resolution: {integrity: sha512-GZsZslMJEyo1VKm5L1ZJY8tGDxZNPAoUeQUIbKeJfoi7Q4kmig5AsgLMYYuyYbfjd8fBmFORAIwYAkXMnXZgZw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-compose-refs@1.0.0':
     resolution: {integrity: sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA==}
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
 
+  '@radix-ui/react-compose-refs@1.1.0':
+    resolution: {integrity: sha512-b4inOtiaOnYf9KWyO3jAeeCG6FeyfY6ldiEPanbUjWd+xIk5wZeHa8yVwmrJ2vderhu/BQvzCrJI0lHd+wIiqw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context-menu@2.2.2':
+    resolution: {integrity: sha512-99EatSTpW+hRYHt7m8wdDlLtkmTovEe8Z/hnxUPV+SKuuNL5HWNhQI4QSdjZqNSgXHay2z4M3Dym73j9p2Gx5Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-context@1.1.0':
+    resolution: {integrity: sha512-OKrckBy+sMEgYM/sMmqmErVn0kZqrHPJze+Ql3DzYsDDp0hl0L62nx/2122/Bvps1qz645jlcu2tD9lrRSdf8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.1':
+    resolution: {integrity: sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-direction@1.1.0':
+    resolution: {integrity: sha512-BUuBvgThEiAXh2DWu93XsT+a3aWrGqolGlqqw5VU1kG7p/ZH2cuDlM1sRLNnY3QcBS69UIz2mcKhMxDsdewhjg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.1':
+    resolution: {integrity: sha512-QSxg29lfr/xcev6kSz7MAlmDnzbP1eI/Dwn3Tp1ip0KT5CUELsxkekFEMVBEoykI3oV39hKT4TKZzBNMbcTZYQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dropdown-menu@2.1.2':
+    resolution: {integrity: sha512-GVZMR+eqK8/Kes0a36Qrv+i20bAPXSn8rCBTHx30w+3ECnR5o3xixAlqcVaYvLeyKUsm0aqyhWfmUcqufM8nYA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.1':
+    resolution: {integrity: sha512-pSIwfrT1a6sIoDASCSpFwOasEwKTZWDw/iBdtnqKO7v6FeOzYJ7U53cPzYFVR3geGGXgVHaH+CdngrrAzqUGxg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.0':
+    resolution: {integrity: sha512-200UD8zylvEyL8Bx+z76RJnASR2gRMuxlgFCPAe/Q/679a/r0eK3MBVYMb7vZODZcffZBdob1EGnky78xmVvcA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-id@1.1.0':
+    resolution: {integrity: sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-menu@2.1.2':
+    resolution: {integrity: sha512-lZ0R4qR2Al6fZ4yCCZzu/ReTFrylHFxIqy7OezIpWF4bL0o9biKo0pFIvkaew3TyZ9Fy5gYVrR5zCGZBVbO1zg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popper@1.2.0':
+    resolution: {integrity: sha512-ZnRMshKF43aBxVWPWvbj21+7TQCvhuULWJ4gNIKYpRlQt5xGRhLx66tMp8pya2UkGHTSlhpXwmjqltDYHhw7Vg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.2':
+    resolution: {integrity: sha512-WeDYLGPxJb/5EGBoedyJbT0MpoULmwnIPMJMSldkuiMsBAv7N1cRdsTWZWht9vpPOiN3qyiGAtbK2is47/uMFg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.1':
+    resolution: {integrity: sha512-IeFXVi4YS1K0wVZzXNrbaaUvIJ3qdY+/Ih4eHFhWA9SwGR9UDX7Ck8abvL57C4cv3wwMvUE0OG69Qc3NCcTe/A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.0.0':
+    resolution: {integrity: sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-roving-focus@1.1.0':
+    resolution: {integrity: sha512-EA6AMGeq9AEeQDeSH0aZgG198qkfHSbvWTf1HvoDmOB5bBG/qTxjYMWUKMnYiV6J/iP/J8MEFSuB2zRU2n7ODA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-slot@1.0.1':
     resolution: {integrity: sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw==}
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
+
+  '@radix-ui/react-slot@1.1.0':
+    resolution: {integrity: sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.0':
+    resolution: {integrity: sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.1.0':
+    resolution: {integrity: sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.0':
+    resolution: {integrity: sha512-L7vwWlR1kTTQ3oh7g1O0CBF3YCyyTj8NmhLR+phShpyA50HCfBFKVJTpshm9PzLiKmehsrQzTYTpX9HvmC9rhw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.0':
+    resolution: {integrity: sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-rect@1.1.0':
+    resolution: {integrity: sha512-0Fmkebhr6PiseyZlYAOtLS+nb7jLmpqTrJyv61Pe68MKYW6OWdRE2kI70TaYY27u7H0lajqM3hSMMLFq18Z7nQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.0':
+    resolution: {integrity: sha512-XW3/vWuIXHa+2Uwcc2ABSfcCledmXhhQPlGbfcRXbiUQI5Icjcg19BGCZVKKInYbvUCut/ufbbLLPFC5cbb1hw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/rect@1.1.0':
+    resolution: {integrity: sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg==}
 
   '@react-native-community/cli-clean@13.6.9':
     resolution: {integrity: sha512-7Dj5+4p9JggxuVNOjPbduZBAP1SUgNhLKVw5noBUzT/3ZpUZkDM+RCSwyoyg8xKWoE4OrdUAXwAFlMcFDPKykA==}
@@ -1474,6 +1774,12 @@ packages:
     resolution: {integrity: sha512-hFJL4cgLPxncJJd/epQ4dHnMg5Jy/7Q56jFvA3MHViuKpzzfTCJCB+pGY54maZbtym53UJON9WTGpM3S81UfjQ==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@react-native-menu/menu@1.1.7':
+    resolution: {integrity: sha512-TPu2iNrSK1Davw5BPhwzcSfMAI9NFggiISOgdlaeymA6L7aAjUGpsEaFVX+ZaHml/YtZUuC8U0zUJJc2/3VYAA==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
 
   '@react-native/assets-registry@0.74.87':
     resolution: {integrity: sha512-1XmRhqQchN+pXPKEKYdpJlwESxVomJOxtEnIkbo7GAlaN2sym84fHEGDXAjLilih5GVPpcpSmFzTy8jx3LtaFg==}
@@ -2055,6 +2361,10 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-hidden@1.2.4:
+    resolution: {integrity: sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==}
+    engines: {node: '>=10'}
 
   array-buffer-byte-length@1.0.1:
     resolution: {integrity: sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==}
@@ -2705,6 +3015,9 @@ packages:
     resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
     engines: {node: '>=0.10'}
     hasBin: true
+
+  detect-node-es@1.1.0:
+    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
@@ -3417,6 +3730,10 @@ packages:
   get-intrinsic@1.2.4:
     resolution: {integrity: sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==}
     engines: {node: '>= 0.4'}
+
+  get-nonce@1.0.1:
+    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
 
   get-port@3.2.0:
     resolution: {integrity: sha512-x5UJKlgeUiNT8nyo/AcnwLnZuZNcSjSw0kogRB+Whd1fjjFq4B1hySFxSFWWSn4mIBzg3sRNUDFYc4g5gjPoLg==}
@@ -5323,6 +5640,21 @@ packages:
     peerDependencies:
       react: ^16.6.0 || ^17.0.0 || ^18.0.0
 
+  react-native-ios-context-menu@2.5.3:
+    resolution: {integrity: sha512-RMztfU71XiLuxnmf/eE4/ez6FT4dzFAzrsHEA0+QmMfaQMHjpyEHTfLJvvM++9gygBvLZmHuc/rQgzQzH7ETug==}
+    peerDependencies:
+      expo: '*'
+      react: '*'
+      react-native: '*'
+      react-native-ios-utilities: '>= 4.4.x <=4.5.x'
+
+  react-native-ios-utilities@4.5.1:
+    resolution: {integrity: sha512-A8PMME94PXv1Ui5WrTBcz69zVPAshvvIuYxJUkE09Nl1Ca6/ds6wCxys/A+KkNPtgeVCN7diBR/M5BTVnJbKDQ==}
+    peerDependencies:
+      expo: '*'
+      react: '*'
+      react-native: '*'
+
   react-native-iphone-screen-helper@2.1.2:
     resolution: {integrity: sha512-xczoNSb582bPW9na9f5ASlJ19vn/JBJ/jPzZ8f+u06F3tCa23dOIml7d4tHmbHdmVaWqf6tgRc95+tyavWg4Fw==}
     peerDependencies:
@@ -5401,10 +5733,40 @@ packages:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
     engines: {node: '>=0.10.0'}
 
+  react-remove-scroll-bar@2.3.6:
+    resolution: {integrity: sha512-DtSYaao4mBmX+HDo5YWYdBWQwYIQQshUV/dVxFxK+KM26Wjwp1gZ6rv6OC3oujI6Bfu6Xyg3TwK533AQutsn/g==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.6.0:
+    resolution: {integrity: sha512-I2U4JVEsQenxDAKaVa3VZ/JeJZe0/2DxPWL8Tj8yLKctQJQiZM52pn/GWFpSp8dftjM3pSAHVJZscAnC/y+ySQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react-shallow-renderer@16.15.0:
     resolution: {integrity: sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==}
     peerDependencies:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0
+
+  react-style-singleton@2.2.1:
+    resolution: {integrity: sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   react-test-renderer@18.3.1:
     resolution: {integrity: sha512-KkAgygexHUkQqtvvx/otwxtuFu5cVjfzTCtjXLH9boS19/Nbtg84zS7wIQn39G8IlrhThBpQsMKkq5ZHZIYFXA==}
@@ -5698,6 +6060,10 @@ packages:
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  sf-symbols-typescript@2.0.0:
+    resolution: {integrity: sha512-Fc8Uhhl2plqXMw7GQ8q83t/zj1xhNCJvteDNJUDULaH/4a/Eqw5aW1UYEznyEIgkokw7QYXuQ9hOw8jhBLXL0A==}
+    engines: {node: '>=10'}
 
   shallow-clone@3.0.1:
     resolution: {integrity: sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==}
@@ -6311,10 +6677,30 @@ packages:
   url-join@4.0.0:
     resolution: {integrity: sha512-EGXjXJZhIHiQMK2pQukuFcL303nskqIRzWvPvV5O8miOfwoUb9G+a/Cld60kUyeaybEI94wvVClT10DtfeAExA==}
 
+  use-callback-ref@1.3.2:
+    resolution: {integrity: sha512-elOQwe6Q8gqZgDA8mrh44qRTQqpIHDcZ3hXTLjBe1i4ph8XpNJnO+aQf3NaG+lriLopI4HMx9VjQLfPQ6vhnoA==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   use-latest-callback@0.2.1:
     resolution: {integrity: sha512-QWlq8Is8BGWBf883QOEQP5HWYX/kMI+JTbJ5rdtvJLmXTIh9XoHIO3PQcmQl8BU44VKxow1kbQUHa6mQSMALDQ==}
     peerDependencies:
       react: '>=16.8'
+
+  use-sidecar@1.1.2:
+    resolution: {integrity: sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': ^16.9.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   use-sync-external-store@1.2.2:
     resolution: {integrity: sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==}
@@ -6576,6 +6962,14 @@ packages:
   yoctocolors-cjs@2.1.2:
     resolution: {integrity: sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==}
     engines: {node: '>=18'}
+
+  zeego@2.0.4:
+    resolution: {integrity: sha512-mkKfUJmgcSGCTqWXW7ccqap8d8z6guQoLF5/mWlH17Jckd0BaFLVZ74y/uWvfBGaC9OawYVt/1MchPnQ8ieSxg==}
+    peerDependencies:
+      '@react-native-menu/menu': '*'
+      react: '*'
+      react-native: '*'
+      react-native-ios-context-menu: ~2.5.1
 
   zod@3.23.8:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
@@ -7586,6 +7980,8 @@ snapshots:
       expo: 51.0.32(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))
       flatted: 3.3.1
 
+  '@dominicstop/ts-event-emitter@1.1.0': {}
+
   '@egjs/hammerjs@2.0.17':
     dependencies:
       '@types/hammerjs': 2.0.45
@@ -7929,6 +8325,23 @@ snapshots:
       chalk: 4.1.2
       find-up: 5.0.0
       js-yaml: 4.1.0
+
+  '@floating-ui/core@1.6.8':
+    dependencies:
+      '@floating-ui/utils': 0.2.8
+
+  '@floating-ui/dom@1.6.12':
+    dependencies:
+      '@floating-ui/core': 1.6.8
+      '@floating-ui/utils': 0.2.8
+
+  '@floating-ui/react-dom@2.1.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@floating-ui/dom': 1.6.12
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@floating-ui/utils@0.2.8': {}
 
   '@formatjs/ecma402-abstract@2.0.0':
     dependencies:
@@ -8355,16 +8768,256 @@ snapshots:
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
 
+  '@radix-ui/primitive@1.1.0': {}
+
+  '@radix-ui/react-arrow@1.1.0(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.0(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.79
+
+  '@radix-ui/react-collection@1.1.0(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.2.79)(react@18.2.0)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.2.79)(react@18.2.0)
+      '@radix-ui/react-primitive': 2.0.0(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-slot': 1.1.0(@types/react@18.2.79)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.79
+
   '@radix-ui/react-compose-refs@1.0.0(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.25.6
       react: 18.2.0
+
+  '@radix-ui/react-compose-refs@1.1.0(@types/react@18.2.79)(react@18.2.0)':
+    dependencies:
+      react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.79
+
+  '@radix-ui/react-context-menu@2.2.2(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-context': 1.1.1(@types/react@18.2.79)(react@18.2.0)
+      '@radix-ui/react-menu': 2.1.2(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-primitive': 2.0.0(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.2.79)(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.2.79)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.79
+
+  '@radix-ui/react-context@1.1.0(@types/react@18.2.79)(react@18.2.0)':
+    dependencies:
+      react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.79
+
+  '@radix-ui/react-context@1.1.1(@types/react@18.2.79)(react@18.2.0)':
+    dependencies:
+      react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.79
+
+  '@radix-ui/react-direction@1.1.0(@types/react@18.2.79)(react@18.2.0)':
+    dependencies:
+      react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.79
+
+  '@radix-ui/react-dismissable-layer@1.1.1(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.2.79)(react@18.2.0)
+      '@radix-ui/react-primitive': 2.0.0(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.2.79)(react@18.2.0)
+      '@radix-ui/react-use-escape-keydown': 1.1.0(@types/react@18.2.79)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.79
+
+  '@radix-ui/react-dropdown-menu@2.1.2(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.2.79)(react@18.2.0)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.2.79)(react@18.2.0)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.2.79)(react@18.2.0)
+      '@radix-ui/react-menu': 2.1.2(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-primitive': 2.0.0(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.2.79)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.79
+
+  '@radix-ui/react-focus-guards@1.1.1(@types/react@18.2.79)(react@18.2.0)':
+    dependencies:
+      react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.79
+
+  '@radix-ui/react-focus-scope@1.1.0(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.2.79)(react@18.2.0)
+      '@radix-ui/react-primitive': 2.0.0(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.2.79)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.79
+
+  '@radix-ui/react-id@1.1.0(@types/react@18.2.79)(react@18.2.0)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.2.79)(react@18.2.0)
+      react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.79
+
+  '@radix-ui/react-menu@2.1.2(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-collection': 1.1.0(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.2.79)(react@18.2.0)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.2.79)(react@18.2.0)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.2.79)(react@18.2.0)
+      '@radix-ui/react-dismissable-layer': 1.1.1(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-focus-guards': 1.1.1(@types/react@18.2.79)(react@18.2.0)
+      '@radix-ui/react-focus-scope': 1.1.0(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.2.79)(react@18.2.0)
+      '@radix-ui/react-popper': 1.2.0(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-portal': 1.1.2(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-presence': 1.1.1(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-primitive': 2.0.0(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-roving-focus': 1.1.0(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-slot': 1.1.0(@types/react@18.2.79)(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.2.79)(react@18.2.0)
+      aria-hidden: 1.2.4
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-remove-scroll: 2.6.0(@types/react@18.2.79)(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.79
+
+  '@radix-ui/react-popper@1.2.0(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-arrow': 1.1.0(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.2.79)(react@18.2.0)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.2.79)(react@18.2.0)
+      '@radix-ui/react-primitive': 2.0.0(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.2.79)(react@18.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.2.79)(react@18.2.0)
+      '@radix-ui/react-use-rect': 1.1.0(@types/react@18.2.79)(react@18.2.0)
+      '@radix-ui/react-use-size': 1.1.0(@types/react@18.2.79)(react@18.2.0)
+      '@radix-ui/rect': 1.1.0
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.79
+
+  '@radix-ui/react-portal@1.1.2(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.0(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.2.79)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.79
+
+  '@radix-ui/react-presence@1.1.1(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.2.79)(react@18.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.2.79)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.79
+
+  '@radix-ui/react-primitive@2.0.0(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@radix-ui/react-slot': 1.1.0(@types/react@18.2.79)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.79
+
+  '@radix-ui/react-roving-focus@1.1.0(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-collection': 1.1.0(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.2.79)(react@18.2.0)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.2.79)(react@18.2.0)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.2.79)(react@18.2.0)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.2.79)(react@18.2.0)
+      '@radix-ui/react-primitive': 2.0.0(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.2.79)(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.2.79)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.79
 
   '@radix-ui/react-slot@1.0.1(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.25.6
       '@radix-ui/react-compose-refs': 1.0.0(react@18.2.0)
       react: 18.2.0
+
+  '@radix-ui/react-slot@1.1.0(@types/react@18.2.79)(react@18.2.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.2.79)(react@18.2.0)
+      react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.79
+
+  '@radix-ui/react-use-callback-ref@1.1.0(@types/react@18.2.79)(react@18.2.0)':
+    dependencies:
+      react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.79
+
+  '@radix-ui/react-use-controllable-state@1.1.0(@types/react@18.2.79)(react@18.2.0)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.2.79)(react@18.2.0)
+      react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.79
+
+  '@radix-ui/react-use-escape-keydown@1.1.0(@types/react@18.2.79)(react@18.2.0)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.2.79)(react@18.2.0)
+      react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.79
+
+  '@radix-ui/react-use-layout-effect@1.1.0(@types/react@18.2.79)(react@18.2.0)':
+    dependencies:
+      react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.79
+
+  '@radix-ui/react-use-rect@1.1.0(@types/react@18.2.79)(react@18.2.0)':
+    dependencies:
+      '@radix-ui/rect': 1.1.0
+      react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.79
+
+  '@radix-ui/react-use-size@1.1.0(@types/react@18.2.79)(react@18.2.0)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.2.79)(react@18.2.0)
+      react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.79
+
+  '@radix-ui/rect@1.1.0': {}
 
   '@react-native-community/cli-clean@13.6.9':
     dependencies:
@@ -8512,6 +9165,11 @@ snapshots:
       - encoding
       - supports-color
       - utf-8-validate
+
+  '@react-native-menu/menu@1.1.7(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      react: 18.2.0
+      react-native: 0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.2.79)(react@18.2.0)
 
   '@react-native/assets-registry@0.74.87': {}
 
@@ -9247,6 +9905,10 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-hidden@1.2.4:
+    dependencies:
+      tslib: 2.7.0
+
   array-buffer-byte-length@1.0.1:
     dependencies:
       call-bind: 1.0.7
@@ -9955,6 +10617,8 @@ snapshots:
   destroy@1.2.0: {}
 
   detect-libc@1.0.3: {}
+
+  detect-node-es@1.1.0: {}
 
   didyoumean@1.2.2: {}
 
@@ -10899,6 +11563,8 @@ snapshots:
       has-proto: 1.0.3
       has-symbols: 1.0.3
       hasown: 2.0.2
+
+  get-nonce@1.0.1: {}
 
   get-port@3.2.0: {}
 
@@ -12933,6 +13599,20 @@ snapshots:
       react-fast-compare: 3.2.2
       shallowequal: 1.1.0
 
+  react-native-ios-context-menu@2.5.3(expo@51.0.32(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(react-native-ios-utilities@4.5.1(expo@51.0.32(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      '@dominicstop/ts-event-emitter': 1.1.0
+      expo: 51.0.32(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      react: 18.2.0
+      react-native: 0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.2.79)(react@18.2.0)
+      react-native-ios-utilities: 4.5.1(expo@51.0.32(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
+
+  react-native-ios-utilities@4.5.1(expo@51.0.32(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      expo: 51.0.32(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      react: 18.2.0
+      react-native: 0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.2.79)(react@18.2.0)
+
   react-native-iphone-screen-helper@2.1.2(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.2.79)(react@18.2.0)):
     dependencies:
       react-native: 0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.2.79)(react@18.2.0)
@@ -13059,11 +13739,39 @@ snapshots:
 
   react-refresh@0.14.2: {}
 
+  react-remove-scroll-bar@2.3.6(@types/react@18.2.79)(react@18.2.0):
+    dependencies:
+      react: 18.2.0
+      react-style-singleton: 2.2.1(@types/react@18.2.79)(react@18.2.0)
+      tslib: 2.7.0
+    optionalDependencies:
+      '@types/react': 18.2.79
+
+  react-remove-scroll@2.6.0(@types/react@18.2.79)(react@18.2.0):
+    dependencies:
+      react: 18.2.0
+      react-remove-scroll-bar: 2.3.6(@types/react@18.2.79)(react@18.2.0)
+      react-style-singleton: 2.2.1(@types/react@18.2.79)(react@18.2.0)
+      tslib: 2.7.0
+      use-callback-ref: 1.3.2(@types/react@18.2.79)(react@18.2.0)
+      use-sidecar: 1.1.2(@types/react@18.2.79)(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.79
+
   react-shallow-renderer@16.15.0(react@18.2.0):
     dependencies:
       object-assign: 4.1.1
       react: 18.2.0
       react-is: 18.3.1
+
+  react-style-singleton@2.2.1(@types/react@18.2.79)(react@18.2.0):
+    dependencies:
+      get-nonce: 1.0.1
+      invariant: 2.2.4
+      react: 18.2.0
+      tslib: 2.7.0
+    optionalDependencies:
+      '@types/react': 18.2.79
 
   react-test-renderer@18.3.1(react@18.2.0):
     dependencies:
@@ -13414,6 +14122,8 @@ snapshots:
   setimmediate@1.0.5: {}
 
   setprototypeof@1.2.0: {}
+
+  sf-symbols-typescript@2.0.0: {}
 
   shallow-clone@3.0.1:
     dependencies:
@@ -14028,9 +14738,24 @@ snapshots:
 
   url-join@4.0.0: {}
 
+  use-callback-ref@1.3.2(@types/react@18.2.79)(react@18.2.0):
+    dependencies:
+      react: 18.2.0
+      tslib: 2.7.0
+    optionalDependencies:
+      '@types/react': 18.2.79
+
   use-latest-callback@0.2.1(react@18.2.0):
     dependencies:
       react: 18.2.0
+
+  use-sidecar@1.1.2(@types/react@18.2.79)(react@18.2.0):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 18.2.0
+      tslib: 2.7.0
+    optionalDependencies:
+      '@types/react': 18.2.79
 
   use-sync-external-store@1.2.2(react@18.2.0):
     dependencies:
@@ -14289,6 +15014,20 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yoctocolors-cjs@2.1.2: {}
+
+  zeego@2.0.4(@react-native-menu/menu@1.1.7(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react-native-ios-context-menu@2.5.3(expo@51.0.32(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(react-native-ios-utilities@4.5.1(expo@51.0.32(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      '@radix-ui/react-context-menu': 2.2.2(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-dropdown-menu': 2.1.2(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-native-menu/menu': 1.1.7(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+      react-native: 0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.2.79)(react@18.2.0)
+      react-native-ios-context-menu: 2.5.3(expo@51.0.32(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(react-native-ios-utilities@4.5.1(expo@51.0.32(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
+      sf-symbols-typescript: 2.0.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react-dom
 
   zod@3.23.8: {}
 

--- a/src/api/habits/augment-participant-pictures.tsx
+++ b/src/api/habits/augment-participant-pictures.tsx
@@ -1,47 +1,45 @@
 import { addTestDelay } from '../common';
 import { type UserIdT } from '../users';
 import { mockPictures } from '../users/mock-users';
-import { type HabitT, type HabitWithParticipantPicturesT } from './types';
+import { type HabitT } from './types';
 
 export const augmentParticipantsWithPicturesForAllHabits = async (
   habits: HabitT[],
 ) => {
-  const habitsWithUserPictures: HabitWithParticipantPicturesT[] = habits.map(
-    (habit) => ({
-      ...habit,
-      participants: Object.fromEntries(
-        Object.entries(habit.participants).map(([id, participant]) => {
-          try {
-            const picture = mockPictures[id as UserIdT];
-            return [
-              id,
-              {
-                ...participant,
-                picture: {
-                  url: picture,
-                  isPending: false,
-                  isError: false,
-                  error: null,
-                },
+  const habitsWithUserPictures: HabitT[] = habits.map((habit) => ({
+    ...habit,
+    participants: Object.fromEntries(
+      Object.entries(habit.participants).map(([id, participant]) => {
+        try {
+          const picture = mockPictures[id as UserIdT];
+          return [
+            id,
+            {
+              ...participant,
+              picture: {
+                url: picture,
+                isPending: false,
+                isError: false,
+                error: null,
               },
-            ];
-          } catch (error) {
-            return [
-              id,
-              {
-                ...participant,
-                picture: {
-                  url: null,
-                  isPending: false,
-                  isError: true,
-                  error: error as string,
-                },
+            },
+          ];
+        } catch (error) {
+          return [
+            id,
+            {
+              ...participant,
+              picture: {
+                url: null,
+                isPending: false,
+                isError: true,
+                error: error as string,
               },
-            ];
-          }
-        }),
-      ),
-    }),
-  );
+            },
+          ];
+        }
+      }),
+    ),
+  }));
   return addTestDelay(habitsWithUserPictures);
 };

--- a/src/api/habits/mock-habits.tsx
+++ b/src/api/habits/mock-habits.tsx
@@ -1,73 +1,107 @@
 import {
   type AllCompletionsT,
+  type DbHabitT,
   type HabitIdT,
-  type HabitWithParticipantsT,
   type UserIdT,
 } from '@/api';
-import { habitColors } from '@/ui/colors';
 
-export const mockHabits: HabitWithParticipantsT[] = [
+export const mockHabits: { id: HabitIdT; data: DbHabitT }[] = [
   {
     id: '1' as HabitIdT,
-    color: habitColors.orange,
-    createdAt: new Date('2024-01-01'),
-    description: 'Drink 8 glasses of water daily',
-    title: 'Stay Hydrated',
-    goal: {
-      period: 'daily',
-      completionsPerPeriod: 8,
-    },
-    icon: '💧',
-    participants: {
-      ['1' as UserIdT]: {
-        displayName: 'John Doe',
-        username: 'johndoe',
-        mostRecentCompletionDate: new Date('2024-01-15'),
-        isOwner: true,
+    data: {
+      colorName: 'orange',
+      createdAt: new Date('2024-01-01T00:00:00'),
+      description: 'Drink 8 glasses of water daily',
+      title: 'Stay Hydrated',
+      goal: {
+        period: 'daily',
+        completionsPerPeriod: 8,
+      },
+      icon: '💧',
+      participants: {
+        ['1' as UserIdT]: {
+          displayName: 'John Doe',
+          username: 'johndoe',
+          mostRecentCompletionDate: new Date('2024-12-01T00:00:00'),
+          isOwner: true,
+        },
+        ['2' as UserIdT]: {
+          displayName: 'Sarah Johnson',
+          username: 'sarahj',
+          mostRecentCompletionDate: new Date('2024-12-08T00:00:00'),
+          isOwner: false,
+        },
+        ['3' as UserIdT]: {
+          displayName: 'Mike Wilson',
+          username: 'mikew',
+          mostRecentCompletionDate: new Date('2024-12-08T00:00:00'),
+          isOwner: false,
+        },
+        ['4' as UserIdT]: {
+          displayName: 'Emily Brown',
+          username: 'emilyb',
+          mostRecentCompletionDate: new Date('2024-12-07T00:00:00'),
+          isOwner: false,
+        },
+        ['5' as UserIdT]: {
+          displayName: 'Chris Lee',
+          username: 'chrisl',
+          mostRecentCompletionDate: new Date('2024-12-03T00:00:00'),
+          isOwner: false,
+        },
       },
     },
   },
   {
     id: '2' as HabitIdT,
-    color: habitColors.green,
-    createdAt: new Date('2024-01-02'),
-    description: 'Go for a 30-minute run',
-    title: 'Daily Exercise',
-    goal: {
-      period: 'daily',
-      completionsPerPeriod: 2,
-    },
-    icon: '🏃',
-    participants: {
-      ['2' as UserIdT]: {
-        displayName: 'Jane Smith',
-        username: 'janesmith',
-        mostRecentCompletionDate: new Date('2024-01-15'),
-        isOwner: true,
+    data: {
+      colorName: 'green',
+      createdAt: new Date('2024-01-02T00:00:00'),
+      description: 'Go for a 30-minute run',
+      title: 'Daily Exercise',
+      goal: {
+        period: 'daily',
+        completionsPerPeriod: 2,
+      },
+      icon: '🏃',
+      participants: {
+        ['1' as UserIdT]: {
+          displayName: 'Jane Smith',
+          username: 'janesmith',
+          mostRecentCompletionDate: new Date('2024-01-15T00:00:00'),
+          isOwner: true,
+        },
       },
     },
   },
   {
     id: '3' as HabitIdT,
-    color: habitColors.purple,
-    createdAt: new Date('2024-01-03'),
-    description: 'Read for 20 minutes before bed',
-    title: 'Daily Reading',
-    goal: {
-      period: 'daily',
-      completionsPerPeriod: 1,
-    },
-    icon: '📚',
-    participants: {
-      ['3' as UserIdT]: {
-        displayName: 'Alex Chen',
-        username: 'alexchen',
-        mostRecentCompletionDate: new Date('2024-01-15'),
-        isOwner: true,
+    data: {
+      colorName: 'purple',
+      createdAt: new Date('2024-01-03T00:00:00'),
+      description: 'Read for 20 minutes before bed',
+      title: 'Daily Reading',
+      goal: {
+        period: 'daily',
+        completionsPerPeriod: 1,
+      },
+      icon: '📚',
+      participants: {
+        ['1' as UserIdT]: {
+          displayName: 'Alex Chen',
+          username: 'alexchen',
+          mostRecentCompletionDate: new Date('2024-12-01T00:00:00'),
+          isOwner: true,
+        },
       },
     },
   },
 ];
+export const setMockHabits = (
+  newHabits: { id: HabitIdT; data: DbHabitT }[],
+) => {
+  Object.assign(mockHabits, newHabits);
+};
 
 export const mockHabitCompletions: Record<HabitIdT, AllCompletionsT> = {
   ['1' as HabitIdT]: {
@@ -76,6 +110,34 @@ export const mockHabitCompletions: Record<HabitIdT, AllCompletionsT> = {
         '2024-12-04': 0,
         '2024-12-05': 1,
         '2024-12-06': 1,
+      },
+    },
+    ['2' as UserIdT]: {
+      completions: {
+        '2024-12-04': 2,
+        '2024-12-05': 3,
+        '2024-12-06': 1,
+      },
+    },
+    ['3' as UserIdT]: {
+      completions: {
+        '2024-12-04': 1,
+        '2024-12-05': 2,
+        '2024-12-06': 2,
+      },
+    },
+    ['4' as UserIdT]: {
+      completions: {
+        '2024-12-04': 3,
+        '2024-12-05': 1,
+        '2024-12-06': 0,
+      },
+    },
+    ['4' as UserIdT]: {
+      completions: {
+        '2024-12-04': 3,
+        '2024-12-05': 1,
+        '2024-12-06': 0,
       },
     },
   },

--- a/src/api/habits/types.ts
+++ b/src/api/habits/types.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import { colorSchema } from '../colors-schemas';
+import { colorSchema, habitColorsSchema } from '../colors-schemas';
 import { UserIdSchema, type UserIdT, userPictureSchema } from '../users/types';
 
 export type HabitIdT = string & { readonly __brand: unique symbol };
@@ -8,80 +8,26 @@ export const HabitIdSchema = z.coerce
   .string()
   .transform((val) => val as HabitIdT);
 
-export const habitCompletionPeriodSchema = z.enum(['daily', 'weekly']);
-export type HabitCompletionPeriodT = z.infer<
-  typeof habitCompletionPeriodSchema
->;
+// ----------------------------------------
+// everything exactly how it's represented in firebase
+// ----------------------------------------
 
-export const participantSchema = z.object({
+// PARTICIPANTS
+export const dbParticipantSchema = z.object({
   displayName: z.string(),
   username: z.string(),
   mostRecentCompletionDate: z.date(),
   isOwner: z.boolean().optional(),
 });
-export type ParticipantT = z.infer<typeof participantSchema>;
+export type DbParticipantT = z.infer<typeof dbParticipantSchema>;
 
-export const participantsSchema = z.record(
-  UserIdSchema,
-  z.object({
-    displayName: z.string(),
-    username: z.string(),
-    mostRecentCompletionDate: z.date(),
-    isOwner: z.boolean().optional(),
-  }),
-);
-export type ParticipantsT = Record<UserIdT, ParticipantT>;
+export const dbParticipantsSchema = z.record(UserIdSchema, dbParticipantSchema);
+export type DbParticipantsT = Record<UserIdT, DbParticipantT>;
 
-export const participantsWithPictureSchema = z.record(
-  UserIdSchema,
-  participantSchema.extend({
-    picture: userPictureSchema,
-  }),
-);
-export type ParticipantsWithPictureT = Record<
-  UserIdT,
-  ParticipantT & { picture: string }
->;
-
-export const habitInfoSchema = z.object({
-  color: colorSchema,
-  createdAt: z.date(),
-  description: z.string(),
-  title: z.string(),
-  goal: z.object({
-    period: habitCompletionPeriodSchema,
-    completionsPerPeriod: z.number(),
-  }),
-  icon: z.string(),
-});
-export type HabitInfoT = z.infer<typeof habitInfoSchema>;
-
-export const habitInfoWithIdSchema = habitInfoSchema.extend({
-  id: HabitIdSchema,
-});
-export type HabitInfoWithIdT = z.infer<typeof habitInfoWithIdSchema>;
-
-export const habitSchema = habitInfoWithIdSchema.extend({
-  participants: participantsWithPictureSchema,
-});
-export type HabitT = z.infer<typeof habitSchema>;
-
-export const habitWithParticipantsSchema = habitInfoWithIdSchema.extend({
-  participants: participantsSchema,
-});
-export type HabitWithParticipantsT = z.infer<
-  typeof habitWithParticipantsSchema
->;
-
-export const habitWithParticipantPicturesSchema = habitInfoWithIdSchema.extend({
-  participants: participantsWithPictureSchema,
-});
-export type HabitWithParticipantPicturesT = z.infer<
-  typeof habitWithParticipantPicturesSchema
->;
-
+// COMPLETIONS
 export const participantCompletionsSchema = z.object({
-  completions: z.record(z.string(), z.number()), // { date: numberOfCompletions }
+  // { date: numberOfCompletions }; ex. { '2021-01-01': 3 }
+  completions: z.record(z.string(), z.number()),
 });
 export type ParticipantCompletionsT = z.infer<
   typeof participantCompletionsSchema
@@ -93,10 +39,10 @@ export const allCompletionsSchema = z.record(
 );
 export type AllCompletionsT = z.infer<typeof allCompletionsSchema>;
 
-export const completeHabit = habitWithParticipantPicturesSchema.extend({
-  ...participantCompletionsSchema.shape,
-});
-export type HabitWithCompletionsT = z.infer<typeof completeHabit>;
+export const habitCompletionPeriodSchema = z.enum(['daily', 'weekly']);
+export type HabitCompletionPeriodT = z.infer<
+  typeof habitCompletionPeriodSchema
+>;
 
 export const habitCompletionWithDateInfoSchema = z.object({
   date: z.string(),
@@ -107,3 +53,70 @@ export const habitCompletionWithDateInfoSchema = z.object({
 export type HabitCompletionWithDateInfoT = z.infer<
   typeof habitCompletionWithDateInfoSchema
 >;
+
+// HABITS
+export const dbHabitInfoSchema = z.object({
+  createdAt: z.date(),
+  description: z.string(),
+  title: z.string(),
+  goal: z.object({
+    period: habitCompletionPeriodSchema,
+    completionsPerPeriod: z.number(),
+  }),
+  icon: z.string(),
+  colorName: z.enum(habitColorsSchema.keyof().options),
+});
+export type DbHabitInfoT = z.infer<typeof dbHabitInfoSchema>;
+
+export const dbHabitSchema = dbHabitInfoSchema.extend({
+  participants: dbParticipantsSchema,
+});
+export type DbHabitT = z.infer<typeof dbHabitSchema>;
+
+// ----------------------------------------
+// extended/improved types for the frontend
+// ----------------------------------------
+
+// PARTICIPANTS
+const participantSchema = dbParticipantSchema
+  // indicator of whether the user has activity today instead of the most recent completion date
+  .omit({ mostRecentCompletionDate: true })
+  .extend({
+    hasActivityToday: z.boolean(),
+    // include the user's picture (needs to fetch from firebase storage)
+    picture: userPictureSchema,
+  });
+
+export const participantWithIdSchema = participantSchema.extend({
+  id: UserIdSchema,
+});
+export type ParticipantWithIdT = z.infer<typeof participantWithIdSchema>;
+
+// define participant without id to make it clear which one is being used
+export const participantWithoutIdSchema = participantSchema;
+export type ParticipantWithoutIdT = z.infer<typeof participantWithoutIdSchema>;
+
+export const participantsSchema = z.record(
+  UserIdSchema,
+  participantWithoutIdSchema,
+);
+export type ParticipantsT = z.infer<typeof participantsSchema>;
+
+// HABITS
+export const habitInfoSchema = dbHabitInfoSchema.extend({
+  // include color object with light, base, faded, and text colors
+  color: colorSchema,
+  // include the habit's id
+  id: HabitIdSchema,
+});
+export type HabitInfoT = z.infer<typeof habitInfoSchema>;
+
+export const habitSchema = habitInfoSchema.extend({
+  participants: participantsSchema,
+});
+export type HabitT = z.infer<typeof habitSchema>;
+
+export const HabitWithCompletions = habitSchema.extend({
+  ...participantCompletionsSchema.shape,
+});
+export type HabitWithCompletionsT = z.infer<typeof HabitWithCompletions>;

--- a/src/api/users/augment-user-pictures.tsx
+++ b/src/api/users/augment-user-pictures.tsx
@@ -21,7 +21,6 @@ export const augmentUsersWithPictures = async (users: CompleteUserT[]) => {
         },
       };
     } catch (error) {
-      console.log('Error fetching user picture');
       showMessage({
         message: 'Error fetching image(s)',
         type: 'danger',

--- a/src/api/users/use-friends.tsx
+++ b/src/api/users/use-friends.tsx
@@ -12,19 +12,18 @@ type Variables = void;
 export const useFriends = createQuery<Response, Variables, Error>({
   queryKey: ['friends'],
   fetcher: async () => {
-    const cachedData: Response | undefined = queryClient.getQueryData<Response>(
-      ['friends'],
-    );
-    if (cachedData) {
-      return cachedData;
-    }
-
     const friends = await addTestDelay(
       mockUsers.filter((user) => user.isFriend),
     );
+
+    const cachedData: Response | undefined = queryClient.getQueryData<Response>(
+      ['friends'],
+    );
+
     const friendsWithPictures = friends.map((friend) => ({
       ...friend,
-      picture: loadingPicture,
+      picture:
+        cachedData?.find((h) => h.id === friend.id)?.picture ?? loadingPicture,
     }));
 
     augmentUsersWithPictures(friendsWithPictures).then((augmentedFriends) => {

--- a/src/api/users/use-user-search.tsx
+++ b/src/api/users/use-user-search.tsx
@@ -16,13 +16,6 @@ export const useUserSearch: ReturnType<
 > = createQuery<Response, Variables, Error>({
   queryKey: ['user-search'],
   fetcher: async (variables) => {
-    const cachedData: Response | undefined = queryClient.getQueryData<Response>(
-      useUserSearch.getKey(variables),
-    );
-    if (cachedData) {
-      return cachedData;
-    }
-
     const users = await addTestDelay(
       mockUsers.filter(
         (user) =>
@@ -32,13 +25,18 @@ export const useUserSearch: ReturnType<
           user.username.toLowerCase().includes(variables.query.toLowerCase()),
       ),
     );
+
+    const cachedData: Response | undefined = queryClient.getQueryData<Response>(
+      useUserSearch.getKey(variables),
+    );
+
     const usersWithPictures = users.map((user) => ({
       ...user,
-      picture: loadingPicture,
+      picture:
+        cachedData?.find((h) => h.id === user.id)?.picture ?? loadingPicture,
     }));
 
     augmentUsersWithPictures(usersWithPictures).then((augmentedUsers) => {
-      console.log('augmentedFriends', augmentedUsers);
       queryClient.setQueryData(useUserSearch.getKey(variables), augmentedUsers);
     });
 

--- a/src/api/users/use-user.tsx
+++ b/src/api/users/use-user.tsx
@@ -13,21 +13,18 @@ export const useUser: ReturnType<
 > = createQuery<Response, Variables, Error>({
   queryKey: ['friend'],
   fetcher: async (variables) => {
-    const cachedData: Response | undefined = queryClient.getQueryData<Response>(
-      useUser.getKey(variables),
-    );
-    if (cachedData) {
-      return cachedData;
-    }
-
     const user = await addTestDelay(
       mockUsers.find((user) => user.id === variables.id),
     );
     if (!user) throw new Error('User not found');
 
+    const cachedData: Response | undefined = queryClient.getQueryData<Response>(
+      useUser.getKey(variables),
+    );
+
     const userWithPicture = {
       ...user,
-      picture: loadingPicture,
+      picture: cachedData?.picture ?? loadingPicture,
     };
 
     augmentUsersWithPictures([userWithPicture]).then((user) => {

--- a/src/components/error-message.tsx
+++ b/src/components/error-message.tsx
@@ -5,25 +5,33 @@ import { Button, Text, View } from '@/ui';
 export const ErrorMessage = ({
   error,
   refetch,
+  variant = 'full',
 }: {
   error: Error;
   refetch: () => void;
+  variant?: 'full' | 'compact';
 }) => {
   const [showStack, setShowStack] = useState(false);
 
   return (
-    <View className="flex flex-1 flex-col items-center justify-center gap-4">
+    <View
+      className={`flex flex-1 flex-col items-center justify-center ${variant === 'full' && 'gap-4'}`}
+    >
       <Text className="text-center text-red-500 dark:text-red-500">
         {error.name}: {error.message}
       </Text>
       <Button onPress={() => refetch()} label="Retry" className="w-40" />
-      <Text
-        onPress={() => setShowStack(!showStack)}
-        className="text-sm underline opacity-70"
-      >
-        {showStack ? 'Hide' : 'Show'} Call Stack
-      </Text>
-      {showStack && <Text className="text-xs opacity-50">{error.stack}</Text>}
+      {variant === 'full' && (
+        <Text
+          onPress={() => setShowStack(!showStack)}
+          className="text-sm underline opacity-70"
+        >
+          {showStack ? 'Hide' : 'Show'} Call Stack
+        </Text>
+      )}
+      {variant === 'full' && showStack && (
+        <Text className="text-xs opacity-50">{error.stack}</Text>
+      )}
     </View>
   );
 };

--- a/src/components/picture.tsx
+++ b/src/components/picture.tsx
@@ -5,7 +5,7 @@ import { Image, View } from '@/ui';
 
 interface PictureProps {
   picture: UserPictureT;
-  size: 128 | 40;
+  size: 128 | 40 | 30;
 }
 export default function UserPicture({ picture, size }: PictureProps) {
   return (

--- a/src/core/get-translucent-color.tsx
+++ b/src/core/get-translucent-color.tsx
@@ -1,0 +1,14 @@
+/**
+ * Takes a hex color value and opacity and returns a hex color with alpha channel.
+ * @param colorHexValue - The hex color value (e.g. '#FF0000')
+ * @param opacity - A number between 0 and 1 representing the opacity
+ * @returns A hex color string with alpha channel (e.g. '#FF0000FF')
+ */
+export function getTranslucentColor(colorHexValue: string, opacity: number) {
+  // convert opacity to 0-255 range
+  const roundedOpacity = Math.round(opacity * 255);
+  // convert to hex string
+  const hexOpacity = roundedOpacity.toString(16).padStart(2, '0');
+  // return rgba value (works because you can define a number as rgba using #RRGGBBAA)
+  return `${colorHexValue}${hexOpacity}`;
+}

--- a/src/core/habit-order.ts
+++ b/src/core/habit-order.ts
@@ -1,0 +1,76 @@
+import { useCallback, useMemo } from 'react';
+import { useMMKVString } from 'react-native-mmkv';
+
+import { type HabitIdT } from '@/api';
+
+const HABIT_ORDER_KEY = 'habit-order';
+
+// Types
+type HabitOrder = HabitIdT[];
+type Direction = 'up' | 'down';
+
+export function useHabitOrder() {
+  const [order, setOrder] = useMMKVString(HABIT_ORDER_KEY);
+  const parsedOrder = useMemo<HabitOrder>(
+    () => (order ? JSON.parse(order) : []),
+    [order],
+  );
+
+  const initializeOrder = useCallback(
+    (habitIds: HabitIdT[]) => {
+      if (!parsedOrder.length) {
+        setOrder(JSON.stringify(habitIds));
+      }
+    },
+    [parsedOrder.length, setOrder],
+  );
+
+  const canMoveHabit = useCallback(
+    (habitId: HabitIdT, direction: Direction) => {
+      const currentIndex = parsedOrder.indexOf(habitId);
+      if (currentIndex === -1) return false;
+
+      if (direction === 'up' && currentIndex === 0) return false;
+      if (direction === 'down' && currentIndex === parsedOrder.length - 1)
+        return false;
+
+      return true;
+    },
+    [parsedOrder],
+  );
+
+  const moveHabit = useCallback(
+    (habitId: HabitIdT, direction: Direction) => {
+      if (!canMoveHabit(habitId, direction)) return;
+
+      const currentIndex = parsedOrder.indexOf(habitId);
+      const newIndex = direction === 'up' ? currentIndex - 1 : currentIndex + 1;
+      const newOrder = [...parsedOrder];
+      [newOrder[currentIndex], newOrder[newIndex]] = [
+        newOrder[newIndex],
+        newOrder[currentIndex],
+      ];
+
+      setOrder(JSON.stringify(newOrder));
+    },
+    [parsedOrder, setOrder, canMoveHabit],
+  );
+
+  const sortHabits = useCallback(
+    <T extends { id: HabitIdT }>(habits: T[]): T[] => {
+      if (!parsedOrder.length) return habits;
+      return [...habits].sort(
+        (a, b) => parsedOrder.indexOf(a.id) - parsedOrder.indexOf(b.id),
+      );
+    },
+    [parsedOrder],
+  );
+
+  return {
+    order: parsedOrder,
+    moveHabit,
+    canMoveHabit,
+    initializeOrder,
+    sortHabits,
+  };
+}

--- a/src/core/hooks/use-selected-theme.tsx
+++ b/src/core/hooks/use-selected-theme.tsx
@@ -32,7 +32,6 @@ export const useSelectedTheme = () => {
 export const loadSelectedTheme = () => {
   const theme = storage.getString(SELECTED_THEME);
   if (theme !== undefined) {
-    console.log('theme', theme);
     colorScheme.set(theme as ColorSchemeType);
   }
 };

--- a/src/core/index.tsx
+++ b/src/core/index.tsx
@@ -1,4 +1,5 @@
 export * from './auth';
 export * from './confetti';
+export * from './habit-order';
 export * from './hooks';
 export * from './utils';

--- a/src/ui/dropdown-menu.tsx
+++ b/src/ui/dropdown-menu.tsx
@@ -1,0 +1,7 @@
+import * as ZeegoMenu from 'zeego/dropdown-menu';
+
+export const DropdownMenuRoot = ZeegoMenu.Root;
+export const DropdownMenuTrigger = ZeegoMenu.Trigger;
+export const DropdownMenuContent = ZeegoMenu.Content;
+export const DropdownMenuItem = ZeegoMenu.Item;
+export const DropdownMenuItemTitle = ZeegoMenu.ItemTitle;

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -3,6 +3,7 @@ import Svg from 'react-native-svg';
 
 export * from './button';
 export { default as colors } from './colors';
+export * from './dropdown-menu';
 export * from './focus-aware-status-bar';
 export * from './header';
 export * from './image';


### PR DESCRIPTION
### TL;DR

Added participant activity display, dropdown menus (native menus using Zeego) + reordering habits using mmkv, and improved some caching logic and types.

Unfortunately, when you click the menu 3 dots button when it is on the bottom half of the screen, it opens the menu upwards and reverses the direction of all the menu items. This puts the "move up in list" button below the "move down in list" button. This is just an iOS thing. I think I'll just ignore it, it's not that bad.

Right now, the edit & delete habit buttons do nothing

https://github.com/user-attachments/assets/25cbd2db-afe0-4278-96c7-f13f0ac2b7f9

### What changed?

- Added dropdown menu to reorder habits in the list
- Enhanced habit cards with participant activity indicators
- Added translucent color utility for the badge color
- Integrated zeego library for dropdown menus
- Added participant activity badges showing who's active today
- Improved profile picture display with active/inactive status indicators
- Restructured habit data types for better type safety

### How to test?

1. Open the habits list screen
2. Click the ellipsis menu on any habit card
3. Try moving habits up/down in the list
4. Verify participant pictures show correct active/inactive states
5. Check that the "X active today" badge updates correctly
6. Confirm habit order persists after app reload