### PR TITLE
feat: implement new relationship model

### DIFF
--- a/src/api/users/mock-users.tsx
+++ b/src/api/users/mock-users.tsx
@@ -1,40 +1,35 @@
-import { type UserIdT, type UserWithFriendStatusT } from './types';
+import { type RelationshipT, type UserIdT, type UserT } from './types';
 
-export const mockUsers: UserWithFriendStatusT[] = [
+export const mockUsers: UserT[] = [
   {
     id: '1' as UserIdT,
     displayName: 'John Doe',
     username: 'john_doe',
     createdAt: new Date(),
-    isFriend: true,
   },
   {
     id: '2' as UserIdT,
     displayName: 'Jane Doe',
     username: 'jane_doe',
     createdAt: new Date(),
-    isFriend: true,
   },
   {
     id: '3' as UserIdT,
     displayName: 'Apple Smith',
     username: 'apple',
     createdAt: new Date(),
-    isFriend: false,
   },
   {
     id: '4' as UserIdT,
     displayName: 'Bob Johnson',
     username: 'bob_johnson',
     createdAt: new Date(),
-    isFriend: true,
   },
   {
     id: '5' as UserIdT,
     displayName: 'Lorem Ipsum',
     username: 'lorem_ipsum',
     createdAt: new Date(),
-    isFriend: false,
   },
 ];
 
@@ -44,4 +39,22 @@ export const mockPictures: Record<UserIdT, string> = {
   ['3' as UserIdT]: 'https://randomuser.me/api/portraits/women/4.jpg',
   ['4' as UserIdT]: 'https://randomuser.me/api/portraits/men/5.jpg',
   ['5' as UserIdT]: 'https://randomuser.me/api/portraits/men/6.jpg',
+};
+
+export const mockRelationships: Record<
+  UserIdT,
+  Record<UserIdT, RelationshipT>
+> = {
+  ['1' as UserIdT]: {
+    ['2' as UserIdT]: { status: 'friends', friendsSince: new Date() },
+    ['4' as UserIdT]: { status: 'friends', friendsSince: new Date() },
+  },
+  ['2' as UserIdT]: {
+    ['1' as UserIdT]: { status: 'friends', friendsSince: new Date() },
+    ['4' as UserIdT]: { status: 'friends', friendsSince: new Date() },
+  },
+  ['4' as UserIdT]: {
+    ['1' as UserIdT]: { status: 'friends', friendsSince: new Date() },
+    ['2' as UserIdT]: { status: 'friends', friendsSince: new Date() },
+  },
 };

--- a/src/api/users/types.ts
+++ b/src/api/users/types.ts
@@ -22,19 +22,32 @@ export const userSchema = dbUserSchema.extend({
 });
 export type UserT = z.infer<typeof userSchema>;
 
-export const friendStatusSchema = z.object({
-  isFriend: z.boolean(),
-});
-export type FriendStatusT = z.infer<typeof friendStatusSchema>;
+export const dbRelationshipStatusSchema = z.enum([
+  'pending',
+  'friends',
+  'blocked',
+]);
+export type dbRelationshipStatusT = z.infer<typeof dbRelationshipStatusSchema>;
 
-export const userWithFriendStatusSchema = userSchema.extend({
-  ...friendStatusSchema.shape,
-});
-export type UserWithFriendStatusT = z.infer<typeof userWithFriendStatusSchema>;
+export const relationshipStatusSchema = z.enum([
+  ...dbRelationshipStatusSchema.options,
+  'none',
+]);
+export type RelationshipStatusT = z.infer<typeof relationshipStatusSchema>;
 
-export const friendshipSchema = z.object({
-  user1Id: UserIdSchema,
-  user2Id: UserIdSchema,
-  friendsSince: z.date(),
+export const relationshipSchema = z.union([
+  z.object({
+    status: dbRelationshipStatusSchema.extract(['friends']),
+    friendsSince: z.date(),
+  }),
+  z.object({
+    status: relationshipStatusSchema.exclude(['friends']),
+    friendsSince: z.undefined(),
+  }),
+]);
+export type RelationshipT = z.infer<typeof relationshipSchema>;
+
+export const userWithRelationshipSchema = userSchema.extend({
+  relationship: relationshipSchema,
 });
-export type FriendshipT = z.infer<typeof friendshipSchema>;
+export type UserWithRelationshipT = z.infer<typeof userWithRelationshipSchema>;

--- a/src/api/users/use-friends.tsx
+++ b/src/api/users/use-friends.tsx
@@ -1,20 +1,28 @@
 import { createQuery } from 'react-query-kit';
 
 import { addTestDelay } from '../common';
-import { mockUsers } from './mock-users';
-import { type UserT } from './types';
+import { mockRelationships, mockUsers } from './mock-users';
+import { type UserIdT, type UserWithRelationshipT } from './types';
 
-type Response = UserT[];
+type Response = UserWithRelationshipT[];
 type Variables = void;
 
 // don't need friend status
 export const useFriends = createQuery<Response, Variables, Error>({
   queryKey: ['friends'],
   fetcher: async () => {
+    const myId = '1' as UserIdT;
     const friends = await addTestDelay(
-      mockUsers.filter((user) => user.isFriend),
+      mockUsers
+        .filter((user) => {
+          const relationship = mockRelationships[myId][user.id];
+          return relationship && relationship.status === 'friends';
+        })
+        .map((user) => ({
+          ...user,
+          relationship: mockRelationships[myId][user.id],
+        })),
     );
-
     return friends;
   },
 });

--- a/src/api/users/use-user.tsx
+++ b/src/api/users/use-user.tsx
@@ -1,22 +1,29 @@
 import { createQuery } from 'react-query-kit';
 
 import { addTestDelay } from '../common';
-import { mockUsers } from './mock-users';
-import { type UserIdT, type UserT } from './types';
+import { mockRelationships, mockUsers } from './mock-users';
+import { type UserIdT, type UserWithRelationshipT } from './types';
 
 type Variables = { id: UserIdT };
-type Response = UserT;
+type Response = UserWithRelationshipT;
 
 export const useUser: ReturnType<
   typeof createQuery<Response, Variables, Error>
 > = createQuery<Response, Variables, Error>({
   queryKey: ['friend'],
   fetcher: async (variables) => {
+    const myId = '1' as UserIdT;
     const user = await addTestDelay(
       mockUsers.find((user) => user.id === variables.id),
     );
     if (!user) throw new Error('User not found');
 
-    return user;
+    return {
+      ...user,
+      relationship: (mockRelationships &&
+        mockRelationships[myId]?.[variables.id]) || {
+        status: 'none',
+      },
+    };
   },
 });

--- a/src/components/profile.tsx
+++ b/src/components/profile.tsx
@@ -1,20 +1,20 @@
 import { Trash2Icon, UserPlus } from 'lucide-react-native';
 import * as React from 'react';
 
-import { type UserT } from '@/api';
+import { type UserWithRelationshipT } from '@/api';
 import { useFriendManagement } from '@/core';
 import { Button, Text, View } from '@/ui';
 
 import UserPicture from './picture';
 
-export default function Profile({ data }: { data: UserT }) {
+export default function Profile({ data }: { data: UserWithRelationshipT }) {
   const {
     isFriend,
     handleSendFriendRequest,
     handleRemoveFriend,
     isAddPending,
     isRemovePending,
-  } = useFriendManagement(data.id, false);
+  } = useFriendManagement(data.id, data.relationship.status === 'friends');
 
   return (
     <View className="flex flex-col items-center gap-4">
@@ -37,6 +37,16 @@ export default function Profile({ data }: { data: UserT }) {
             day: 'numeric',
           })}
         </Text>
+        {data.relationship.friendsSince && (
+          <Text className="text-center text-sm font-medium text-stone-400 dark:text-stone-400">
+            Friends Since{' '}
+            {data.relationship.friendsSince.toLocaleDateString('en-US', {
+              year: 'numeric',
+              month: 'long',
+              day: 'numeric',
+            })}
+          </Text>
+        )}
       </View>
       {isFriend ? (
         <Button


### PR DESCRIPTION
### TL;DR
Refactored user relationship management to support multiple relationship statuses and tracking friendship dates.

IMPORTANT: relationships will now be stored differently in the DB

Now it's:

```
// collection of users
id: {
    createdAt: Date,
    displayName: string,
    username: string, 
    // subcollection of relationships
    relationships: [
        status: "pending" | "friends" | "blocked",
        friendsSince: Date | undefined,
    ],
}
```

So each user with have a subcollection of relationships.

### What changed?
- Replaced boolean `isFriend` flag with a comprehensive relationship system
- Added new relationship types: 'pending', 'friends', 'blocked', and 'none'
- Introduced `mockRelationships` to store relationship data between users
- Updated user profile to display "Friends Since" date when applicable
- Modified user queries to include relationship information in responses

### How to test?
1. View different user profiles to verify relationship status display
2. Check that "Friends Since" date appears for users who are friends
3. Verify friend management actions (add/remove) work with new relationship system
4. Confirm friends list only shows users with 'friends' status

### Why make this change?
To provide a more robust relationship management system that supports additional states beyond simple friend/not-friend, while also tracking important relationship metadata like when friendships began.