### PR TITLE
feat: add habit entry modification with notes and images

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -67,6 +67,12 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
         ],
       },
     ],
+    [
+      'expo-image-picker',
+      {
+        cameraPermission: 'The camera is used to take pictures of your habits.',
+      },
+    ],
   ],
   extra: {
     ...ClientEnv,

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "expo-dev-client": "~4.0.25",
     "expo-font": "~12.0.9",
     "expo-image": "~1.13.0",
+    "expo-image-picker": "~15.0.7",
     "expo-linking": "~6.3.1",
     "expo-router": "~3.5.23",
     "expo-splash-screen": "0.27.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       expo-image:
         specifier: ~1.13.0
         version: 1.13.0(expo@51.0.39(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2)))
+      expo-image-picker:
+        specifier: ~15.0.7
+        version: 15.0.7(expo@51.0.39(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2)))
       expo-linking:
         specifier: ~6.3.1
         version: 6.3.1(expo@51.0.39(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2)))
@@ -3459,6 +3462,16 @@ packages:
 
   expo-font@12.0.10:
     resolution: {integrity: sha512-Q1i2NuYri3jy32zdnBaHHCya1wH1yMAsI+3CCmj9zlQzlhsS9Bdwcj2W3c5eU5FvH2hsNQy4O+O1NnM6o/pDaQ==}
+    peerDependencies:
+      expo: '*'
+
+  expo-image-loader@4.7.0:
+    resolution: {integrity: sha512-cx+MxxsAMGl9AiWnQUzrkJMJH4eNOGlu7XkLGnAXSJrRoIiciGaKqzeaD326IyCTV+Z1fXvIliSgNW+DscvD8g==}
+    peerDependencies:
+      expo: '*'
+
+  expo-image-picker@15.0.7:
+    resolution: {integrity: sha512-u8qiPZNfDb+ap6PJ8pq2iTO7JKX+ikAUQ0K0c7gXGliKLxoXgDdDmXxz9/6QdICTshJBJlBvI0MwY5NWu7A/uw==}
     peerDependencies:
       expo: '*'
 
@@ -11286,6 +11299,15 @@ snapshots:
     dependencies:
       expo: 51.0.39(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))
       fontfaceobserver: 2.3.0
+
+  expo-image-loader@4.7.0(expo@51.0.39(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))):
+    dependencies:
+      expo: 51.0.39(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+
+  expo-image-picker@15.0.7(expo@51.0.39(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))):
+    dependencies:
+      expo: 51.0.39(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))
+      expo-image-loader: 4.7.0(expo@51.0.39(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2)))
 
   expo-image@1.13.0(expo@51.0.39(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))):
     dependencies:

--- a/src/api/habits/mock-habits.tsx
+++ b/src/api/habits/mock-habits.tsx
@@ -106,56 +106,60 @@ export const setMockHabits = (
 export const mockHabitCompletions: Record<HabitIdT, AllCompletionsT> = {
   ['1' as HabitIdT]: {
     ['1' as UserIdT]: {
-      completions: {
-        '2024-12-04': 0,
-        '2024-12-05': 1,
-        '2024-12-06': 1,
+      entries: {
+        '2024-12-04': { numberOfCompletions: 0 },
+        '2024-12-05': { numberOfCompletions: 1 },
+        '2024-12-06': { numberOfCompletions: 1 },
+        '2024-12-18': {
+          numberOfCompletions: 1,
+          note: 'Drank 8 glasses of water today!',
+        },
       },
     },
     ['2' as UserIdT]: {
-      completions: {
-        '2024-12-04': 2,
-        '2024-12-05': 3,
-        '2024-12-06': 1,
+      entries: {
+        '2024-12-04': { numberOfCompletions: 2 },
+        '2024-12-05': { numberOfCompletions: 3 },
+        '2024-12-06': { numberOfCompletions: 1 },
       },
     },
     ['3' as UserIdT]: {
-      completions: {
-        '2024-12-04': 1,
-        '2024-12-05': 2,
-        '2024-12-06': 2,
+      entries: {
+        '2024-12-04': { numberOfCompletions: 1 },
+        '2024-12-05': { numberOfCompletions: 2 },
+        '2024-12-06': { numberOfCompletions: 2 },
       },
     },
     ['4' as UserIdT]: {
-      completions: {
-        '2024-12-04': 3,
-        '2024-12-05': 1,
-        '2024-12-06': 0,
+      entries: {
+        '2024-12-04': { numberOfCompletions: 3 },
+        '2024-12-05': { numberOfCompletions: 1 },
+        '2024-12-06': { numberOfCompletions: 0 },
       },
     },
-    ['4' as UserIdT]: {
-      completions: {
-        '2024-12-04': 3,
-        '2024-12-05': 1,
-        '2024-12-06': 0,
+    ['5' as UserIdT]: {
+      entries: {
+        '2024-12-04': { numberOfCompletions: 3 },
+        '2024-12-05': { numberOfCompletions: 1 },
+        '2024-12-06': { numberOfCompletions: 0 },
       },
     },
   },
   ['2' as HabitIdT]: {
     ['1' as UserIdT]: {
-      completions: {
-        '2024-12-04': 1,
-        '2024-12-05': 0,
-        '2024-12-06': 1,
+      entries: {
+        '2024-12-04': { numberOfCompletions: 1 },
+        '2024-12-05': { numberOfCompletions: 0 },
+        '2024-12-06': { numberOfCompletions: 1 },
       },
     },
   },
   ['3' as HabitIdT]: {
     ['1' as UserIdT]: {
-      completions: {
-        '2024-12-04': 0,
-        '2024-12-05': 0,
-        '2024-12-06': 1,
+      entries: {
+        '2024-12-04': { numberOfCompletions: 0 },
+        '2024-12-05': { numberOfCompletions: 0 },
+        '2024-12-06': { numberOfCompletions: 1 },
       },
     },
   },

--- a/src/api/habits/types.ts
+++ b/src/api/habits/types.ts
@@ -25,9 +25,16 @@ export const dbParticipantsSchema = z.record(UserIdSchema, dbParticipantSchema);
 export type DbParticipantsT = Record<UserIdT, DbParticipantT>;
 
 // COMPLETIONS
+export const habitEntrySchema = z.object({
+  numberOfCompletions: z.number(),
+  note: z.string().optional(),
+  image: z.string().optional(),
+});
+export type HabitEntryT = z.infer<typeof habitEntrySchema>;
+
 export const participantCompletionsSchema = z.object({
   // { date: numberOfCompletions }; ex. { '2021-01-01': 3 }
-  completions: z.record(z.string(), z.number()),
+  entries: z.record(z.string(), habitEntrySchema),
 });
 export type ParticipantCompletionsT = z.infer<
   typeof participantCompletionsSchema
@@ -44,14 +51,13 @@ export type HabitCompletionPeriodT = z.infer<
   typeof habitCompletionPeriodSchema
 >;
 
-export const habitCompletionWithDateInfoSchema = z.object({
+export const habitEntryWithDateInfoSchema = habitEntrySchema.extend({
   date: z.string(),
-  numberOfCompletions: z.number(),
   dayOfTheMonth: z.number(),
   dayOfTheWeek: z.string(),
 });
 export type HabitCompletionWithDateInfoT = z.infer<
-  typeof habitCompletionWithDateInfoSchema
+  typeof habitEntryWithDateInfoSchema
 >;
 
 // HABITS

--- a/src/api/habits/use-habit-completions.tsx
+++ b/src/api/habits/use-habit-completions.tsx
@@ -16,7 +16,7 @@ type Variables = {
 };
 
 export const useHabitCompletions = createQuery<Response, Variables, Error>({
-  queryKey: ['habits-completions'],
+  queryKey: ['habit-completions'],
   fetcher: async (variables) => {
     const completions = mockHabitCompletions[variables.habitId];
     if (!completions) {
@@ -45,15 +45,16 @@ function getStructuredCompletionData(
   currentDate.setDate(currentDate.getDate() - numDays + 1);
   // loop through each day and add the completion data for that day to the structured data
   for (let i = 0; i < numDays; i++) {
+    const dateString = currentDate.toLocaleDateString('en-CA');
     // if there is no completion data for the current date, default to 0 (no completions that day)
     structuredCompletionData.push({
       numberOfCompletions:
-        completionData?.completions?.[
-          currentDate.toLocaleDateString('en-CA')
-        ] ?? 0,
+        completionData.entries?.[dateString]?.numberOfCompletions ?? 0,
       dayOfTheMonth: currentDate.getDate(),
       dayOfTheWeek: currentDate.toLocaleString('en-US', { weekday: 'short' }),
       date: currentDate.toLocaleDateString('en-CA'),
+      note: completionData.entries?.[dateString]?.note,
+      image: completionData.entries?.[dateString]?.image,
     });
     // move current date ahead 1 day
     currentDate.setDate(currentDate.getDate() + 1);

--- a/src/api/users/mock-users.tsx
+++ b/src/api/users/mock-users.tsx
@@ -1,40 +1,35 @@
-import { type UserIdT, type UserWithFriendStatusT } from './types';
+import { type RelationshipT, type UserIdT, type UserT } from './types';
 
-export const mockUsers: UserWithFriendStatusT[] = [
+export const mockUsers: UserT[] = [
   {
     id: '1' as UserIdT,
     displayName: 'John Doe',
     username: 'john_doe',
     createdAt: new Date(),
-    isFriend: true,
   },
   {
     id: '2' as UserIdT,
     displayName: 'Jane Doe',
     username: 'jane_doe',
     createdAt: new Date(),
-    isFriend: true,
   },
   {
     id: '3' as UserIdT,
     displayName: 'Apple Smith',
     username: 'apple',
     createdAt: new Date(),
-    isFriend: false,
   },
   {
     id: '4' as UserIdT,
     displayName: 'Bob Johnson',
     username: 'bob_johnson',
     createdAt: new Date(),
-    isFriend: true,
   },
   {
     id: '5' as UserIdT,
     displayName: 'Lorem Ipsum',
     username: 'lorem_ipsum',
     createdAt: new Date(),
-    isFriend: false,
   },
 ];
 
@@ -44,4 +39,22 @@ export const mockPictures: Record<UserIdT, string> = {
   ['3' as UserIdT]: 'https://randomuser.me/api/portraits/women/4.jpg',
   ['4' as UserIdT]: 'https://randomuser.me/api/portraits/men/5.jpg',
   ['5' as UserIdT]: 'https://randomuser.me/api/portraits/men/6.jpg',
+};
+
+export const mockRelationships: Record<
+  UserIdT,
+  Record<UserIdT, RelationshipT>
+> = {
+  ['1' as UserIdT]: {
+    ['2' as UserIdT]: { status: 'friends', friendsSince: new Date() },
+    ['4' as UserIdT]: { status: 'friends', friendsSince: new Date() },
+  },
+  ['2' as UserIdT]: {
+    ['1' as UserIdT]: { status: 'friends', friendsSince: new Date() },
+    ['4' as UserIdT]: { status: 'friends', friendsSince: new Date() },
+  },
+  ['4' as UserIdT]: {
+    ['1' as UserIdT]: { status: 'friends', friendsSince: new Date() },
+    ['2' as UserIdT]: { status: 'friends', friendsSince: new Date() },
+  },
 };

--- a/src/api/users/types.ts
+++ b/src/api/users/types.ts
@@ -22,19 +22,32 @@ export const userSchema = dbUserSchema.extend({
 });
 export type UserT = z.infer<typeof userSchema>;
 
-export const friendStatusSchema = z.object({
-  isFriend: z.boolean(),
-});
-export type FriendStatusT = z.infer<typeof friendStatusSchema>;
+export const dbRelationshipStatusSchema = z.enum([
+  'pending',
+  'friends',
+  'blocked',
+]);
+export type dbRelationshipStatusT = z.infer<typeof dbRelationshipStatusSchema>;
 
-export const userWithFriendStatusSchema = userSchema.extend({
-  ...friendStatusSchema.shape,
-});
-export type UserWithFriendStatusT = z.infer<typeof userWithFriendStatusSchema>;
+export const relationshipStatusSchema = z.enum([
+  ...dbRelationshipStatusSchema.options,
+  'none',
+]);
+export type RelationshipStatusT = z.infer<typeof relationshipStatusSchema>;
 
-export const friendshipSchema = z.object({
-  user1Id: UserIdSchema,
-  user2Id: UserIdSchema,
-  friendsSince: z.date(),
+export const relationshipSchema = z.union([
+  z.object({
+    status: dbRelationshipStatusSchema.extract(['friends']),
+    friendsSince: z.date(),
+  }),
+  z.object({
+    status: relationshipStatusSchema.exclude(['friends']),
+    friendsSince: z.undefined(),
+  }),
+]);
+export type RelationshipT = z.infer<typeof relationshipSchema>;
+
+export const userWithRelationshipSchema = userSchema.extend({
+  relationship: relationshipSchema,
 });
-export type FriendshipT = z.infer<typeof friendshipSchema>;
+export type UserWithRelationshipT = z.infer<typeof userWithRelationshipSchema>;

--- a/src/api/users/use-friends.tsx
+++ b/src/api/users/use-friends.tsx
@@ -1,20 +1,28 @@
 import { createQuery } from 'react-query-kit';
 
 import { addTestDelay } from '../common';
-import { mockUsers } from './mock-users';
-import { type UserT } from './types';
+import { mockRelationships, mockUsers } from './mock-users';
+import { type UserIdT, type UserWithRelationshipT } from './types';
 
-type Response = UserT[];
+type Response = UserWithRelationshipT[];
 type Variables = void;
 
 // don't need friend status
 export const useFriends = createQuery<Response, Variables, Error>({
   queryKey: ['friends'],
   fetcher: async () => {
+    const myId = '1' as UserIdT;
     const friends = await addTestDelay(
-      mockUsers.filter((user) => user.isFriend),
+      mockUsers
+        .filter((user) => {
+          const relationship = mockRelationships[myId][user.id];
+          return relationship && relationship.status === 'friends';
+        })
+        .map((user) => ({
+          ...user,
+          relationship: mockRelationships[myId][user.id],
+        })),
     );
-
     return friends;
   },
 });

--- a/src/api/users/use-user.tsx
+++ b/src/api/users/use-user.tsx
@@ -1,22 +1,29 @@
 import { createQuery } from 'react-query-kit';
 
 import { addTestDelay } from '../common';
-import { mockUsers } from './mock-users';
-import { type UserIdT, type UserT } from './types';
+import { mockRelationships, mockUsers } from './mock-users';
+import { type UserIdT, type UserWithRelationshipT } from './types';
 
 type Variables = { id: UserIdT };
-type Response = UserT;
+type Response = UserWithRelationshipT;
 
 export const useUser: ReturnType<
   typeof createQuery<Response, Variables, Error>
 > = createQuery<Response, Variables, Error>({
   queryKey: ['friend'],
   fetcher: async (variables) => {
+    const myId = '1' as UserIdT;
     const user = await addTestDelay(
       mockUsers.find((user) => user.id === variables.id),
     );
     if (!user) throw new Error('User not found');
 
-    return user;
+    return {
+      ...user,
+      relationship: (mockRelationships &&
+        mockRelationships[myId]?.[variables.id]) || {
+        status: 'none',
+      },
+    };
   },
 });

--- a/src/app/auth/index.tsx
+++ b/src/app/auth/index.tsx
@@ -75,9 +75,9 @@ export default function Auth() {
             onPress={handleSubmit(onSubmit)}
           />
           <View className="flex-row items-center gap-3">
-            <View className="h-px flex-1 bg-slate-300 dark:bg-slate-600" />
+            <View className="h-px flex-1 bg-slate-300 dark:bg-stone-600" />
             <Text className="text-slate-300">OR</Text>
-            <View className="h-px flex-1 bg-slate-300 dark:bg-slate-600" />
+            <View className="h-px flex-1 bg-slate-300 dark:bg-stone-600" />
           </View>
 
           <Button

--- a/src/components/modify-habit-entry/completions-section.tsx
+++ b/src/components/modify-habit-entry/completions-section.tsx
@@ -1,0 +1,48 @@
+import { MinusIcon, PlusIcon } from 'lucide-react-native';
+import { useColorScheme } from 'nativewind';
+
+import { Pressable, Text, View } from '@/ui';
+
+interface CompletionsSectionProps {
+  numberOfCompletions: number;
+  setNumberOfCompletions: (value: number | ((prev: number) => number)) => void;
+}
+export function CompletionsSection({
+  numberOfCompletions,
+  setNumberOfCompletions,
+}: CompletionsSectionProps) {
+  const { colorScheme } = useColorScheme();
+  return (
+    <View className="flex flex-col gap-2">
+      <Text className="">Number of Completions</Text>
+      <View className="flex-row items-center justify-center">
+        <Pressable
+          className={`h-12 w-12 items-center justify-center rounded-full border border-slate-200 dark:border-stone-700 ${
+            numberOfCompletions === 0 ? 'opacity-30' : ''
+          }`}
+          onPress={() => {
+            setNumberOfCompletions((prev) => Math.max(0, prev - 1));
+          }}
+          disabled={numberOfCompletions === 0}
+        >
+          <MinusIcon
+            size={16}
+            color={colorScheme === 'dark' ? 'white' : 'black'}
+          />
+        </Pressable>
+        <Text className="w-12 text-center text-2xl">{numberOfCompletions}</Text>
+        <Pressable
+          className="h-12 w-12 items-center justify-center rounded-full border border-slate-200 dark:border-stone-700"
+          onPress={() => {
+            setNumberOfCompletions((prev) => prev + 1);
+          }}
+        >
+          <PlusIcon
+            size={16}
+            color={colorScheme === 'dark' ? 'white' : 'black'}
+          />
+        </Pressable>
+      </View>
+    </View>
+  );
+}

--- a/src/components/modify-habit-entry/day-navigation.tsx
+++ b/src/components/modify-habit-entry/day-navigation.tsx
@@ -1,0 +1,76 @@
+import { ArrowLeftIcon, ArrowRightIcon } from 'lucide-react-native';
+import { useColorScheme } from 'nativewind';
+
+import { type HabitCompletionWithDateInfoT } from '@/api';
+import { Pressable, Text, View } from '@/ui';
+
+interface DayNavigationProps {
+  selectedDayIndex: number;
+  completions: HabitCompletionWithDateInfoT[];
+  hasUnsavedChanges: boolean;
+  onDayChange: (index: number) => void;
+  resetStates: () => void;
+}
+export function DayNavigation({
+  selectedDayIndex,
+  completions,
+  hasUnsavedChanges,
+  onDayChange,
+  resetStates,
+}: DayNavigationProps) {
+  const { colorScheme } = useColorScheme();
+  return (
+    <View className="flex-col gap-2">
+      <View className="flex-row items-center justify-center">
+        <Pressable
+          className="rounded-lg border border-slate-200 px-4 py-2 dark:border-stone-700 dark:bg-transparent"
+          onPress={() => {
+            onDayChange(selectedDayIndex - 1);
+            resetStates();
+          }}
+          disabled={selectedDayIndex === 0 || hasUnsavedChanges}
+          style={{
+            opacity: selectedDayIndex === 0 || hasUnsavedChanges ? 0.3 : 1,
+          }}
+        >
+          <ArrowLeftIcon
+            size={16}
+            color={colorScheme === 'dark' ? 'white' : 'black'}
+          />
+        </Pressable>
+        <Text className="w-32 text-center font-bold">
+          {new Date(
+            new Date(completions[selectedDayIndex].date).setDate(
+              new Date(completions[selectedDayIndex].date).getDate() + 1,
+            ),
+          ).toLocaleDateString('en-US', {
+            weekday: 'short',
+            month: 'short',
+            day: 'numeric',
+          })}
+        </Text>
+        <Pressable
+          className="rounded-lg border border-slate-200 px-4 py-2 dark:border-stone-700 dark:bg-transparent"
+          onPress={() => onDayChange(selectedDayIndex + 1)}
+          disabled={
+            selectedDayIndex === completions.length - 1 || hasUnsavedChanges
+          }
+          style={{
+            opacity:
+              selectedDayIndex === completions.length - 1 || hasUnsavedChanges
+                ? 0.3
+                : 1,
+          }}
+        >
+          <ArrowRightIcon
+            size={16}
+            color={colorScheme === 'dark' ? 'white' : 'black'}
+          />
+        </Pressable>
+      </View>
+      <Text className="text-center text-sm text-orange-500 dark:text-orange-500">
+        {hasUnsavedChanges ? 'You have unsaved changes' : ' '}
+      </Text>
+    </View>
+  );
+}

--- a/src/components/modify-habit-entry/image-section.tsx
+++ b/src/components/modify-habit-entry/image-section.tsx
@@ -1,0 +1,109 @@
+/* eslint-disable max-lines-per-function */
+import * as ImagePicker from 'expo-image-picker';
+import { CameraIcon, ImageIcon, Trash2Icon } from 'lucide-react-native';
+import { useColorScheme } from 'nativewind';
+import { useEffect, useState } from 'react';
+import { Image as RNImage } from 'react-native';
+import { showMessage } from 'react-native-flash-message';
+
+import { Button, colors, Image, Pressable, Text, View } from '@/ui';
+
+interface ImageSectionProps {
+  image: string | undefined;
+  setImage: (image: string | undefined) => void;
+}
+
+export function ImageSection({ image, setImage }: ImageSectionProps) {
+  const { colorScheme } = useColorScheme();
+  const [imageWidth, setImageWidth] = useState(140);
+  const [imageHeight, setImageHeight] = useState(140);
+
+  useEffect(() => {
+    if (image) {
+      RNImage.getSize(
+        image,
+        (width, height) => {
+          const aspectRatio = width / height;
+          setImageWidth(140 * aspectRatio);
+          setImageHeight(140);
+        },
+        (error) => {
+          console.error('Error getting image size:', error);
+        },
+      );
+    }
+  }, [image]);
+
+  const takePhoto = async () => {
+    let canTakePhoto = false;
+
+    const permission = await ImagePicker.getCameraPermissionsAsync();
+    if (permission.granted) {
+      canTakePhoto = true;
+    } else if (permission.canAskAgain) {
+      const newPermission = await ImagePicker.requestCameraPermissionsAsync();
+      if (newPermission.granted) {
+        canTakePhoto = true;
+      }
+    } else {
+      showMessage({
+        message:
+          'Cannot access camera. Please enable camera permissions in settings.',
+        type: 'danger',
+        duration: 2000,
+      });
+    }
+
+    if (canTakePhoto) {
+      const result = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        allowsEditing: true,
+        quality: 1,
+      });
+
+      if (!result.canceled) {
+        setImage(result.assets[0].uri || undefined);
+      }
+    }
+  };
+
+  return (
+    <View className="flex flex-col gap-2">
+      <Text className="">Attach Image</Text>
+      {image ? (
+        <Image
+          source={{
+            uri: image,
+          }}
+          className="mx-auto rounded-lg"
+          style={{
+            height: imageHeight,
+            width: imageWidth,
+          }}
+        />
+      ) : (
+        <Pressable onPress={takePhoto}>
+          <View className="mx-auto h-[140px] w-[140px] rounded-lg bg-neutral-200 dark:border dark:border-stone-700 dark:bg-transparent">
+            <ImageIcon
+              size={32}
+              className="m-auto"
+              color={
+                colorScheme === 'dark' ? colors.stone[700] : colors.neutral[300]
+              }
+              strokeWidth={1}
+            />
+          </View>
+        </Pressable>
+      )}
+      <View className="flex-row items-center space-x-4">
+        <Button
+          icon={image ? Trash2Icon : CameraIcon}
+          label={image ? 'Delete Photo' : 'Take Photo'}
+          variant={image ? 'destructive' : 'default'}
+          className="w-full"
+          onPress={image ? () => setImage(undefined) : takePhoto}
+        />
+      </View>
+    </View>
+  );
+}

--- a/src/components/modify-habit-entry/index.tsx
+++ b/src/components/modify-habit-entry/index.tsx
@@ -1,0 +1,47 @@
+/* eslint-disable max-lines-per-function */
+import { PenIcon } from 'lucide-react-native';
+import React, { useState } from 'react';
+
+import { type HabitCompletionWithDateInfoT, type HabitT } from '@/api';
+import { Pressable, Text, useModal, View } from '@/ui';
+
+import { ModifyEntryModal } from './modify-entry-modal';
+
+export interface ModifyEntryProps {
+  habit: HabitT;
+  completions: HabitCompletionWithDateInfoT[];
+}
+export default function ModifyHabitEntry({
+  habit,
+  completions,
+}: ModifyEntryProps) {
+  const modal = useModal();
+  const [selectedDayIndex, setSelectedDayIndex] = useState<number>(
+    completions.length - 1,
+  );
+
+  return (
+    <>
+      <View className="flex flex-row justify-end">
+        <Pressable
+          className="flex flex-row items-center gap-2 rounded-full border px-4 py-1"
+          style={{ borderColor: habit.color.text }}
+          onPress={modal.present}
+        >
+          <PenIcon size={16} color={habit.color.text} />
+          <Text className="" style={{ color: habit.color.text }}>
+            Modify entry or add note/image
+          </Text>
+        </Pressable>
+      </View>
+
+      <ModifyEntryModal
+        modal={modal}
+        habit={habit}
+        completions={completions}
+        selectedDayIndex={selectedDayIndex}
+        setSelectedDayIndex={setSelectedDayIndex}
+      />
+    </>
+  );
+}

--- a/src/components/modify-habit-entry/modify-entry-modal.tsx
+++ b/src/components/modify-habit-entry/modify-entry-modal.tsx
@@ -1,0 +1,143 @@
+/* eslint-disable max-lines-per-function */
+import { zodResolver } from '@hookform/resolvers/zod';
+import { SaveIcon, XIcon } from 'lucide-react-native';
+import { useColorScheme } from 'nativewind';
+import React, { useCallback, useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+
+import {
+  type HabitCompletionWithDateInfoT,
+  type HabitEntryT,
+  type HabitT,
+  type UserIdT,
+} from '@/api';
+import { useModifyHabitEntry } from '@/api/habits/use-modify-entry';
+import { colors, Header, Modal, type ModalMethods, View } from '@/ui';
+
+import { CompletionsSection } from './completions-section';
+import { DayNavigation } from './day-navigation';
+import { ImageSection } from './image-section';
+import { type NoteFormType, noteSchema, NoteSection } from './note-section';
+
+interface ModifyEntryModalProps {
+  modal: ModalMethods;
+  habit: HabitT;
+  completions: HabitCompletionWithDateInfoT[];
+  selectedDayIndex: number;
+  setSelectedDayIndex: (index: number) => void;
+}
+export function ModifyEntryModal({
+  modal,
+  habit,
+  completions,
+  selectedDayIndex,
+  setSelectedDayIndex,
+}: ModifyEntryModalProps) {
+  const { colorScheme } = useColorScheme();
+  const modifyEntry = useModifyHabitEntry();
+  const selectedCompletion = completions[selectedDayIndex];
+
+  const [numberOfCompletions, setNumberOfCompletions] = useState<number>(
+    selectedCompletion.numberOfCompletions,
+  );
+  const [image, setImage] = useState<string | undefined>(
+    selectedCompletion.image ?? undefined,
+  );
+  const {
+    control: noteControl,
+    handleSubmit: handleNoteSubmit,
+    watch,
+    reset: resetForm,
+  } = useForm<NoteFormType>({
+    resolver: zodResolver(noteSchema),
+    defaultValues: { note: selectedCompletion.note },
+  });
+
+  // Update form when selected day changes
+  useEffect(() => {
+    setNumberOfCompletions(selectedCompletion.numberOfCompletions);
+    setImage(selectedCompletion.image ?? undefined);
+    resetForm({ note: selectedCompletion.note ?? '' });
+  }, [selectedDayIndex, selectedCompletion, resetForm]);
+
+  const resetStates = () => {
+    setNumberOfCompletions(selectedCompletion.numberOfCompletions);
+    resetForm({ note: selectedCompletion.note ?? '' });
+    setImage(selectedCompletion.image ?? undefined);
+  };
+
+  const hasUnsavedChanges = useCallback(() => {
+    const currentNote = watch('note');
+    return (
+      numberOfCompletions !== selectedCompletion.numberOfCompletions ||
+      currentNote !== (selectedCompletion.note ?? '') ||
+      image !== (selectedCompletion.image ?? undefined)
+    );
+  }, [watch, selectedCompletion, numberOfCompletions, image]);
+
+  const handleCancel = () => {
+    resetStates();
+    setSelectedDayIndex(completions.length - 1);
+    modal.dismiss();
+  };
+
+  const handleSave = handleNoteSubmit(async (data) => {
+    const modifiedEntry: HabitEntryT = {
+      numberOfCompletions: numberOfCompletions,
+      note: data.note !== '' ? data.note : undefined,
+      image: image !== '' ? image : undefined,
+    };
+
+    await modifyEntry.mutateAsync({
+      habitId: habit.id,
+      userId: '1' as UserIdT,
+      date: selectedCompletion.date,
+      modifiedEntry: modifiedEntry,
+    });
+
+    resetStates();
+    setSelectedDayIndex(completions.length - 1);
+    modal.dismiss();
+  });
+
+  return (
+    <Modal
+      ref={modal.ref}
+      snapPoints={['90%']}
+      enablePanDownToClose={false}
+      disableBackdropPress={true}
+      hideCloseButton={true}
+      backgroundStyle={{
+        backgroundColor:
+          colorScheme === 'dark' ? colors.neutral[800] : colors.white,
+      }}
+    >
+      <View className="flex-1 px-4">
+        <Header
+          leftButton={{
+            icon: XIcon,
+            text: 'Cancel',
+            onPress: handleCancel,
+          }}
+          title="Modify Habit Entry"
+          rightButton={{ icon: SaveIcon, text: 'Save', onPress: handleSave }}
+        />
+        <View className="flex flex-col gap-4">
+          <DayNavigation
+            selectedDayIndex={selectedDayIndex}
+            completions={completions}
+            hasUnsavedChanges={hasUnsavedChanges()}
+            onDayChange={setSelectedDayIndex}
+            resetStates={resetStates}
+          />
+          <CompletionsSection
+            numberOfCompletions={numberOfCompletions}
+            setNumberOfCompletions={setNumberOfCompletions}
+          />
+          <NoteSection control={noteControl} />
+          <ImageSection image={image} setImage={setImage} />
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/src/components/modify-habit-entry/note-section.tsx
+++ b/src/components/modify-habit-entry/note-section.tsx
@@ -1,0 +1,29 @@
+import { type Control } from 'react-hook-form';
+import { z } from 'zod';
+
+import { ControlledInput, Text, View } from '@/ui';
+
+export const noteSchema = z.object({
+  note: z.string(),
+});
+export type NoteFormType = z.infer<typeof noteSchema>;
+
+interface NoteSectionProps {
+  control: Control<NoteFormType>;
+}
+export function NoteSection({ control }: NoteSectionProps) {
+  return (
+    <View className="flex flex-col gap-2">
+      <View>
+        <Text className="">Add a Note</Text>
+      </View>
+      <ControlledInput
+        control={control}
+        name="note"
+        multiline
+        className="h-20 rounded-lg border border-slate-200 p-2 dark:border-stone-700 dark:text-white"
+        placeholder="Write your note here..."
+      />
+    </View>
+  );
+}

--- a/src/components/profile.tsx
+++ b/src/components/profile.tsx
@@ -1,20 +1,20 @@
 import { Trash2Icon, UserPlus } from 'lucide-react-native';
 import * as React from 'react';
 
-import { type UserT } from '@/api';
+import { type UserWithRelationshipT } from '@/api';
 import { useFriendManagement } from '@/core';
 import { Button, Text, View } from '@/ui';
 
 import UserPicture from './picture';
 
-export default function Profile({ data }: { data: UserT }) {
+export default function Profile({ data }: { data: UserWithRelationshipT }) {
   const {
     isFriend,
     handleSendFriendRequest,
     handleRemoveFriend,
     isAddPending,
     isRemovePending,
-  } = useFriendManagement(data.id, false);
+  } = useFriendManagement(data.id, data.relationship.status === 'friends');
 
   return (
     <View className="flex flex-col items-center gap-4">
@@ -37,6 +37,16 @@ export default function Profile({ data }: { data: UserT }) {
             day: 'numeric',
           })}
         </Text>
+        {data.relationship.friendsSince && (
+          <Text className="text-center text-sm font-medium text-stone-400 dark:text-stone-400">
+            Friends Since{' '}
+            {data.relationship.friendsSince.toLocaleDateString('en-US', {
+              year: 'numeric',
+              month: 'long',
+              day: 'numeric',
+            })}
+          </Text>
+        )}
       </View>
       {isFriend ? (
         <Button

--- a/src/ui/modal.tsx
+++ b/src/ui/modal.tsx
@@ -33,24 +33,33 @@ import type {
   BottomSheetModalProps,
 } from '@gorhom/bottom-sheet';
 import { BottomSheetModal, useBottomSheet } from '@gorhom/bottom-sheet';
+import { type BottomSheetModalMethods } from '@gorhom/bottom-sheet/src/types';
 import * as React from 'react';
 import { Pressable, View } from 'react-native';
-import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
+import Animated from 'react-native-reanimated';
 import { Path, Svg } from 'react-native-svg';
 
 import { Text } from './text';
 
 type ModalProps = BottomSheetModalProps & {
   title?: string;
+  hideCloseButton?: boolean;
+  disableBackdropPress?: boolean;
 };
 
 type ModalRef = React.ForwardedRef<BottomSheetModal>;
 
 type ModalHeaderProps = {
   title?: string;
+  hideCloseButton?: boolean;
   dismiss: () => void;
 };
 
+export type ModalMethods = {
+  ref: React.RefObject<BottomSheetModalMethods>;
+  present: (data?: any) => void;
+  dismiss: () => void;
+};
 export const useModal = () => {
   const ref = React.useRef<BottomSheetModal>(null);
   const present = React.useCallback((data?: any) => {
@@ -67,7 +76,9 @@ export const Modal = React.forwardRef(
     {
       snapPoints: _snapPoints = ['60%'],
       title,
+      hideCloseButton = false,
       detached = false,
+      disableBackdropPress = false,
       ...props
     }: ModalProps,
     ref: ModalRef,
@@ -88,10 +99,14 @@ export const Modal = React.forwardRef(
       () => (
         <>
           <View className="mb-8 mt-2 h-1 w-12 self-center rounded-lg bg-gray-400 dark:bg-gray-700" />
-          <ModalHeader title={title} dismiss={modal.dismiss} />
+          <ModalHeader
+            title={title}
+            dismiss={modal.dismiss}
+            hideCloseButton={hideCloseButton}
+          />
         </>
       ),
-      [title, modal.dismiss],
+      [title, modal.dismiss, hideCloseButton],
     );
 
     return (
@@ -101,7 +116,11 @@ export const Modal = React.forwardRef(
         ref={modal.ref}
         index={0}
         snapPoints={snapPoints}
-        backdropComponent={props.backdropComponent || renderBackdrop}
+        backdropComponent={(backdropProps) =>
+          props.backdropComponent
+            ? props.backdropComponent(backdropProps)
+            : renderBackdrop({ ...backdropProps, disableBackdropPress })
+        }
         handleComponent={renderHandleComponent}
       />
     );
@@ -114,21 +133,22 @@ export const Modal = React.forwardRef(
 
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
-const CustomBackdrop = ({ style }: BottomSheetBackdropProps) => {
+const CustomBackdrop = ({
+  style,
+  disableBackdropPress,
+}: BottomSheetBackdropProps & { disableBackdropPress?: boolean }) => {
   const { close } = useBottomSheet();
   return (
     <AnimatedPressable
-      onPress={() => close()}
-      entering={FadeIn.duration(50)}
-      exiting={FadeOut.duration(20)}
+      onPress={() => !disableBackdropPress && close()}
       style={[style, { backgroundColor: 'rgba(0, 0, 0, 0.4)' }]}
     />
   );
 };
 
-export const renderBackdrop = (props: BottomSheetBackdropProps) => (
-  <CustomBackdrop {...props} />
-);
+export const renderBackdrop = (
+  props: BottomSheetBackdropProps & { disableBackdropPress?: boolean },
+) => <CustomBackdrop {...props} />;
 
 /**
  *
@@ -154,23 +174,25 @@ const getDetachedProps = (detached: boolean) => {
  * ModalHeader
  */
 
-const ModalHeader = React.memo(({ title, dismiss }: ModalHeaderProps) => {
-  return (
-    <>
-      {title && (
-        <View className="flex-row px-2 py-4">
-          <View className="h-[24px] w-[24px]" />
-          <View className="flex-1">
-            <Text className="text-center text-[16px] font-bold text-[#26313D] dark:text-white">
-              {title}
-            </Text>
+const ModalHeader = React.memo(
+  ({ title, dismiss, hideCloseButton }: ModalHeaderProps) => {
+    return (
+      <>
+        {title && (
+          <View className="flex-row px-2 py-4">
+            <View className="h-[24px] w-[24px]" />
+            <View className="flex-1">
+              <Text className="text-center text-[16px] font-bold text-[#26313D] dark:text-white">
+                {title}
+              </Text>
+            </View>
           </View>
-        </View>
-      )}
-      <CloseButton close={dismiss} />
-    </>
-  );
-});
+        )}
+        {!hideCloseButton && <CloseButton close={dismiss} />}
+      </>
+    );
+  },
+);
 
 const CloseButton = ({ close }: { close: () => void }) => {
   return (


### PR DESCRIPTION
### TL;DR

Added ability to upload notes & pictures!!!

I think this is really good because it greatly improves the social aspect. For example, if you're in a habit working out with friends, now you can post a pic of you at the gym as proof and write a note saying what you did

Another important thing: I basically removed the ability to set a certain amount of completions per day. Instead of the square filling up the more completions you do in a day, it just shows a number with how many times you've completed today (see demo).

https://github.com/user-attachments/assets/6500e5d8-9370-4d98-8059-865523ea526f

Maybe we just make it a boolean option to allow multiple completions in a day, since for some habits it doesn't make sense to have multiple a day

This is better because different people doing a habit together might have slightly different goals... like if people want to track how many glasses of water they drink, maybe one person has a "goal" to drink 5 glasses a day, but for another person it's different

### What changed?

- Added support for adding notes and images to habit entries
- Enhanced habit completion tracking to store more detailed entry information
- Integrated expo-image-picker for capturing and selecting images
- Created a new modal interface for modifying habit entries
- Updated the habit card UI to accommodate the new entry modification features
- Restructured habit completion data model to support additional entry metadata

### How to test?

1. Open any habit card
2. Click the "Modify entry or add note/image" button
3. Try modifying the number of completions
4. Add a note to the entry
5. Take or select a photo for the entry
6. Navigate between different days using the arrow buttons
7. Save changes and verify they persist
8. Test camera permissions and image picker functionality