### PR TITLE
feat: implement habit editing functionality

### DIFF
--- a/src/api/habits/index.tsx
+++ b/src/api/habits/index.tsx
@@ -1,4 +1,5 @@
 export * from './types';
 export * from './use-create-habit';
+export * from './use-edit-habit';
 export * from './use-habits';
 export * from './use-press-habit-button';

--- a/src/api/habits/types.ts
+++ b/src/api/habits/types.ts
@@ -124,7 +124,7 @@ export type HabitWithCompletionsT = z.infer<typeof HabitWithCompletions>;
 export const habitCreationSchema = z.object({
   title: z.string().min(1, 'Title is required'),
   description: z.string().optional(),
-  color: z.string().min(1, 'Color is required'),
+  colorName: z.string().min(1, 'Color is required'),
   allowMultipleCompletions: z.boolean(),
   icon: z.enum(Object.keys(habitIcons) as [keyof typeof habitIcons]),
 });

--- a/src/api/habits/use-create-habit.tsx
+++ b/src/api/habits/use-create-habit.tsx
@@ -23,7 +23,7 @@ export const useCreateHabit = createMutation<Response, Variables, Error>({
     const newHabit: DbHabitT = {
       title: variables.habitCreationInfo.title,
       description: variables.habitCreationInfo.description,
-      colorName: variables.habitCreationInfo.color as HabitColorNameT,
+      colorName: variables.habitCreationInfo.colorName as HabitColorNameT,
       icon: variables.habitCreationInfo.icon,
       settings: {
         allowMultipleCompletions:

--- a/src/api/habits/use-edit-habit.tsx
+++ b/src/api/habits/use-edit-habit.tsx
@@ -1,0 +1,52 @@
+import { showMessage } from 'react-native-flash-message';
+import { createMutation } from 'react-query-kit';
+
+import { addTestDelay, queryClient } from '../common';
+import { mockHabits, setMockHabits } from './mock-habits';
+import { type DbHabitT, type HabitCreationT, type HabitIdT } from './types';
+
+type Response = DbHabitT;
+type Variables = {
+  habitId: HabitIdT;
+  newHabitInfo: HabitCreationT;
+};
+
+export const useEditHabit = createMutation<Response, Variables, Error>({
+  mutationFn: async ({ habitId, newHabitInfo }) => {
+    const habitIndex = mockHabits.findIndex((h) => h.id === habitId);
+    if (habitIndex === -1) throw new Error('Habit not found');
+
+    const updatedHabit = {
+      ...mockHabits[habitIndex].data,
+      ...newHabitInfo,
+      colorName: newHabitInfo.colorName as DbHabitT['colorName'],
+      settings: {
+        ...mockHabits[habitIndex].data.settings,
+        allowMultipleCompletions:
+          newHabitInfo.allowMultipleCompletions ??
+          mockHabits[habitIndex].data.settings.allowMultipleCompletions,
+      },
+    };
+
+    const newMockHabits = [...mockHabits];
+    newMockHabits[habitIndex] = { id: habitId, data: updatedHabit };
+    setMockHabits(newMockHabits);
+
+    return await addTestDelay(updatedHabit);
+  },
+  onSuccess: () => {
+    queryClient.invalidateQueries({ queryKey: ['habits'] });
+    showMessage({
+      message: 'Habit updated successfully',
+      type: 'success',
+      duration: 2000,
+    });
+  },
+  onError: () => {
+    showMessage({
+      message: 'Failed to update habit',
+      type: 'danger',
+      duration: 2000,
+    });
+  },
+});

--- a/src/components/habit-card.tsx
+++ b/src/components/habit-card.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines-per-function */
-import { Link } from 'expo-router';
+import { Link, router } from 'expo-router';
 import { ActivityIcon, CheckIcon, EllipsisIcon } from 'lucide-react-native';
 import { useColorScheme } from 'nativewind';
 import React, { useEffect, useState } from 'react';
@@ -69,11 +69,7 @@ export function HabitCard({ habit }: HabitCardProps) {
               colorScheme === 'dark' ? colors.stone.light : habit.color.light,
           }}
         >
-          <HabitHeader
-            habitId={habit.id}
-            title={habit.title}
-            icon={habit.icon}
-          />
+          <HabitHeader habit={habit} />
           <View className="flex flex-row">
             <HabitFriendCompletions habit={habit} />
           </View>
@@ -98,11 +94,9 @@ export function HabitCard({ habit }: HabitCardProps) {
 }
 
 interface HabitHeaderProps {
-  habitId: HabitIdT;
-  title: string;
-  icon: string;
+  habit: HabitT;
 }
-const HabitHeader = ({ habitId, title, icon }: HabitHeaderProps) => {
+const HabitHeader = ({ habit }: HabitHeaderProps) => {
   const { colorScheme } = useColorScheme();
   const { moveHabit, canMoveHabit } = useHabitOrder();
 
@@ -110,20 +104,26 @@ const HabitHeader = ({ habitId, title, icon }: HabitHeaderProps) => {
     {
       key: 'Move up in list',
       title: 'Move up in list',
-      onSelect: () => moveHabit(habitId, 'up'),
-      disabled: !canMoveHabit(habitId, 'up'),
+      onSelect: () => moveHabit(habit.id, 'up'),
+      disabled: !canMoveHabit(habit.id, 'up'),
     },
     {
       key: 'Move down in list',
       title: 'Move down in list',
-      onSelect: () => moveHabit(habitId, 'down'),
-      disabled: !canMoveHabit(habitId, 'down'),
+      onSelect: () => moveHabit(habit.id, 'down'),
+      disabled: !canMoveHabit(habit.id, 'down'),
     },
     {
       key: 'Edit habit',
       title: 'Edit habit',
       onSelect: () => {
-        alert('todo');
+        router.push({
+          pathname: '/habits/edit-habit',
+          params: {
+            mode: 'edit',
+            habit: JSON.stringify(habit),
+          },
+        });
       },
     },
     {
@@ -139,7 +139,7 @@ const HabitHeader = ({ habitId, title, icon }: HabitHeaderProps) => {
     <View className="ml-1 flex-row items-center justify-between">
       <View className="mr-2 flex-1 flex-row items-center gap-1">
         <HabitIcon
-          icon={icon as keyof typeof habitIcons}
+          icon={habit.icon as keyof typeof habitIcons}
           size={24}
           color={colorScheme === 'dark' ? colors.white : colors.black}
         />
@@ -147,7 +147,7 @@ const HabitHeader = ({ habitId, title, icon }: HabitHeaderProps) => {
           numberOfLines={1}
           className="mb-1 flex-1 text-base font-bold text-black dark:text-white"
         >
-          {title}
+          {habit.title}
         </Text>
       </View>
 


### PR DESCRIPTION
### TL;DR
Added habit editing functionality and renamed the color field to colorName for consistency

https://github.com/user-attachments/assets/9ad807f9-cd4e-4c6c-8f8c-0eb2d2625209

### What changed?
- Renamed `color` field to `colorName` in habit creation schema
- Added new `useEditHabit` hook for updating existing habits
- Enhanced the edit-habit screen to support both creation and editing modes
- Added edit functionality to the habit card's menu
- Updated form defaults to populate with existing habit data when editing

### How to test?
1. Create a new habit to verify creation still works
2. Click the menu (three dots) on any habit card
3. Select "Edit habit"
4. Modify any fields (title, description, color, icon, or multiple completions)
5. Click "Save Changes"
6. Verify the habit updates with the new information
7. Verify the success toast appears