### PR TITLE
feat: implement habit detail view with participant activity

### DIFF
--- a/src/api/habits/mock-habits.tsx
+++ b/src/api/habits/mock-habits.tsx
@@ -20,31 +20,31 @@ export const mockHabits: { id: HabitIdT; data: DbHabitT }[] = [
       participants: {
         ['1' as UserIdT]: {
           displayName: 'John Doe',
-          username: 'johndoe',
+          username: 'john_doe',
           lastActivity: new Date('2024-12-01T00:00:00'),
           isOwner: true,
         },
         ['2' as UserIdT]: {
-          displayName: 'Sarah Johnson',
-          username: 'sarahj',
-          lastActivity: new Date('2024-12-08T00:00:00'),
+          displayName: 'Jane Doe',
+          username: 'jane_doe',
+          lastActivity: new Date('2025-01-11T00:00:00'),
           isOwner: false,
         },
         ['3' as UserIdT]: {
-          displayName: 'Mike Wilson',
-          username: 'mikew',
+          displayName: 'Apple Smith',
+          username: 'apple',
           lastActivity: new Date('2024-12-08T00:00:00'),
           isOwner: false,
         },
         ['4' as UserIdT]: {
-          displayName: 'Emily Brown',
-          username: 'emilyb',
+          displayName: 'Bob Johnson',
+          username: 'bob_johnson',
           lastActivity: new Date('2024-12-07T00:00:00'),
           isOwner: false,
         },
         ['5' as UserIdT]: {
-          displayName: 'Chris Lee',
-          username: 'chrisl',
+          displayName: 'Lorem Ipsum',
+          username: 'lorem_ipsum',
           lastActivity: new Date('2024-12-03T00:00:00'),
           isOwner: false,
         },
@@ -64,8 +64,8 @@ export const mockHabits: { id: HabitIdT; data: DbHabitT }[] = [
       icon: 'dumbbell',
       participants: {
         ['1' as UserIdT]: {
-          displayName: 'Jane Smith',
-          username: 'janesmith',
+          displayName: 'John Doe',
+          username: 'john_doe',
           lastActivity: new Date('2024-01-15T00:00:00'),
           isOwner: true,
         },
@@ -85,8 +85,8 @@ export const mockHabits: { id: HabitIdT; data: DbHabitT }[] = [
       icon: 'book',
       participants: {
         ['1' as UserIdT]: {
-          displayName: 'Alex Chen',
-          username: 'alexchen',
+          displayName: 'John Doe',
+          username: 'john_doe',
           lastActivity: new Date('2024-12-01T00:00:00'),
           isOwner: true,
         },
@@ -119,6 +119,7 @@ export const mockHabitCompletions: Record<HabitIdT, AllCompletionsT> = {
         '2024-12-04': { numberOfCompletions: 2 },
         '2024-12-05': { numberOfCompletions: 3 },
         '2024-12-06': { numberOfCompletions: 1 },
+        '2025-01-11': { numberOfCompletions: 1, note: 'Drank 8 glasses' },
       },
     },
     ['3' as UserIdT]: {

--- a/src/api/habits/use-modify-entry.tsx
+++ b/src/api/habits/use-modify-entry.tsx
@@ -96,8 +96,11 @@ export const useModifyHabitEntry = createMutation<Response, Variables, Error>({
     queryClient.invalidateQueries({
       queryKey: [
         'habit-completions',
-        { habitId: variables.habitId, userId: variables.userId },
+        { habitId: variables.habitId, userId: variables.userId, numDays: 7 },
       ],
+    });
+    queryClient.invalidateQueries({
+      queryKey: ['all-users-habit-completions', { habitId: variables.habitId }],
     });
   },
 });

--- a/src/app/habits/view-habit.tsx
+++ b/src/app/habits/view-habit.tsx
@@ -1,32 +1,345 @@
-import { router, useLocalSearchParams } from 'expo-router';
-import { PenIcon } from 'lucide-react-native';
+/* eslint-disable max-lines-per-function */
+import { Link, useLocalSearchParams } from 'expo-router';
+import {
+  BellIcon,
+  CheckIcon,
+  ChevronRightIcon,
+  Trash2Icon,
+  UserPlusIcon,
+} from 'lucide-react-native';
+import { useColorScheme } from 'nativewind';
 import * as React from 'react';
 
-import { type HabitT } from '@/api';
-import { Header, ScreenContainer, Text } from '@/ui';
+import {
+  type HabitColorT,
+  type HabitCompletionWithDateInfoT,
+  type HabitT,
+  type ParticipantWithIdT,
+  useAllUsersHabitCompletions,
+  type UserT,
+} from '@/api';
+import { ErrorMessage } from '@/components/error-message';
+import { HabitIcon, type habitIcons } from '@/components/habit-icon';
+import ModifyHabitEntry from '@/components/modify-habit-entry';
+import { DayNavigation } from '@/components/modify-habit-entry/day-navigation';
+import { UserImageNameAndUsername } from '@/components/user-card';
+import { getTranslucentColor } from '@/core/get-translucent-color';
+import {
+  Button,
+  colors,
+  Header,
+  Image,
+  LoadingSpinner,
+  Modal,
+  Pressable,
+  ScreenContainer,
+  ScrollView,
+  Text,
+  useModal,
+  View,
+} from '@/ui';
 
 export default function ViewHabit() {
   const { habitJson } = useLocalSearchParams<{
     habitJson: string;
   }>();
   const parsedHabit: HabitT = JSON.parse(habitJson);
+  // Parse dates for all participants' lastActivity
+  Object.values(parsedHabit.participants).forEach((participant) => {
+    if (participant?.lastActivity) {
+      participant.lastActivity = new Date(participant.lastActivity);
+    }
+  });
+
+  const generateDatesList = (startDate: Date): Date[] => {
+    const dates: Date[] = [];
+    const start = new Date(startDate);
+    // Set to start of day
+    start.setHours(0, 0, 0, 0);
+
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    while (start <= today) {
+      dates.push(new Date(start));
+      start.setDate(start.getDate() + 1);
+    }
+    return dates;
+  };
+  const datesList = generateDatesList(new Date(parsedHabit.createdAt));
+
+  const {
+    data: allCompletions,
+    isPending: allCompletionsIsPending,
+    isError: allCompletionsIsError,
+    error: allCompletionsError,
+    refetch: refetchCompletions,
+  } = useAllUsersHabitCompletions({
+    variables: {
+      habitId: parsedHabit.id,
+      numDays: datesList.length,
+    },
+  });
+
+  const [selectedDayIndex, setSelectedDayIndex] = React.useState(
+    datesList.length - 1,
+  );
+
+  const handleDayChange = (newIndex: number) => {
+    if (newIndex >= 0 && newIndex < datesList.length) {
+      setSelectedDayIndex(newIndex);
+    }
+  };
+
+  const resetStates = () => {
+    // No form states to reset in this view, but keeping the function
+    // for consistency with the DayNavigation interface
+  };
+
+  const participantsByMostRecentActivity: ParticipantWithIdT[] = Object.values(
+    parsedHabit.participants,
+  )
+    .filter((p): p is ParticipantWithIdT => p !== undefined)
+    .sort((a, b) => {
+      // always show user first
+      if (a.id === '1') return -1;
+      if (b.id === '1') return 1;
+      if (!a?.lastActivity) {
+        console.error('no last activity', a);
+        return 1;
+      }
+      if (!b?.lastActivity) {
+        console.error('no last activity', b);
+        return -1;
+      }
+      return b.lastActivity.getTime() - a.lastActivity.getTime();
+    });
 
   return (
     <ScreenContainer>
-      <Header
-        leftButton="back"
-        rightButton={{
-          icon: PenIcon,
-          text: 'Edit Habit',
-          onPress: () => {
-            router.push({
-              pathname: '/habits/edit-habit',
-              params: { mode: 'edit', habitJson: habitJson },
-            });
-          },
-        }}
-      />
-      <Text>{parsedHabit.id}</Text>
+      <Header leftButton="back" />
+      <ScrollView>
+        <View className="flex flex-1 flex-col gap-6 pb-10">
+          <HabitHeader habit={parsedHabit} />
+          <DayNavigation
+            selectedDayIndex={selectedDayIndex}
+            datesList={datesList}
+            hasUnsavedChanges={false}
+            onDayChange={handleDayChange}
+            resetStates={resetStates}
+          />
+          {allCompletionsIsPending ? (
+            <LoadingSpinner />
+          ) : allCompletionsIsError ? (
+            <ErrorMessage
+              error={allCompletionsError}
+              refetch={refetchCompletions}
+              variant="compact"
+            />
+          ) : (
+            <View className="flex flex-1 flex-col gap-2">
+              {participantsByMostRecentActivity.map((p) => {
+                const user: UserT = {
+                  id: p.id,
+                  displayName: p.displayName,
+                  username: p.username,
+                  createdAt: p.lastActivity,
+                };
+                return (
+                  <UserWithEntry
+                    key={p.id}
+                    user={user}
+                    entry={allCompletions[user.id][selectedDayIndex]}
+                    color={parsedHabit.color}
+                    isToday={selectedDayIndex === datesList.length - 1}
+                    modifyEntryButton={
+                      user.id === '1' && (
+                        <ModifyHabitEntry
+                          habit={parsedHabit}
+                          completions={[
+                            allCompletions[user.id][selectedDayIndex],
+                          ]}
+                          showAsNormalButton
+                        />
+                      )
+                    }
+                  />
+                );
+              })}
+            </View>
+          )}
+        </View>
+      </ScrollView>
     </ScreenContainer>
   );
 }
+
+interface HabitHeaderProps {
+  habit: HabitT;
+}
+const HabitHeader = ({ habit }: HabitHeaderProps) => {
+  const { colorScheme } = useColorScheme();
+  const modal = useModal();
+
+  return (
+    <>
+      <Pressable
+        className="flex-row items-center justify-between rounded-full border border-slate-200 bg-white px-4 py-2 dark:border-stone-700 dark:bg-transparent"
+        onPress={modal.present}
+      >
+        <View className="flex-1 flex-row items-center gap-2">
+          <HabitIcon
+            icon={habit.icon as keyof typeof habitIcons}
+            size={20}
+            color={colorScheme === 'dark' ? colors.white : colors.black}
+            strokeWidth={2}
+          />
+          <Text
+            numberOfLines={1}
+            className="flex-1 text-lg font-semibold text-black dark:text-white"
+          >
+            {habit.title}
+          </Text>
+        </View>
+        <ChevronRightIcon
+          color={colorScheme === 'dark' ? colors.white : colors.black}
+        />
+      </Pressable>
+
+      <Modal
+        ref={modal.ref}
+        snapPoints={['90%']}
+        backgroundStyle={{
+          backgroundColor:
+            colorScheme === 'dark' ? colors.neutral[800] : colors.white,
+        }}
+      >
+        <View className="flex-1 px-4">
+          <Header title={habit.title} />
+          <View className="flex flex-col gap-4">
+            <Button
+              label="Invite Friends"
+              variant="outline"
+              icon={UserPlusIcon}
+              onPress={() => alert('todo')}
+            />
+            <Button
+              label="Leave Habit"
+              variant="destructive"
+              icon={Trash2Icon}
+              onPress={() => alert('todo')}
+            />
+          </View>
+        </View>
+      </Modal>
+    </>
+  );
+};
+
+interface UserWithEntryProps {
+  user: UserT;
+  entry: HabitCompletionWithDateInfoT;
+  color: HabitColorT;
+  modifyEntryButton?: React.ReactNode;
+  isToday: boolean;
+}
+const UserWithEntry = ({
+  user,
+  entry,
+  color,
+  modifyEntryButton,
+  isToday,
+}: UserWithEntryProps) => {
+  const { colorScheme } = useColorScheme();
+  return (
+    <Link
+      push
+      href={{
+        pathname: '/friends/[id]',
+        params: {
+          id: user.id,
+          theirUserId: user.id,
+        },
+      }}
+      asChild
+    >
+      <Pressable className="rounded-3xl border border-stone-200 bg-white p-4 dark:border-stone-700 dark:bg-transparent">
+        <View className="flex flex-col gap-4">
+          <View className="flex flex-row">
+            <View
+              className="flex flex-row items-center rounded-full border px-2 py-1"
+              style={{
+                borderColor:
+                  entry.numberOfCompletions >= 1 ? color.base : 'transparent',
+                backgroundColor:
+                  entry.numberOfCompletions >= 1
+                    ? getTranslucentColor(color.base, 0.15)
+                    : colorScheme === 'dark'
+                      ? colors.stone.light
+                      : colors.stone[100],
+              }}
+            >
+              <Text
+                className="text-xs"
+                style={{
+                  color:
+                    entry.numberOfCompletions === 0
+                      ? colors.stone[400]
+                      : color.base,
+                }}
+              >
+                {entry.numberOfCompletions === 0 ? (
+                  'Not completed'
+                ) : (
+                  <>
+                    Completed{' '}
+                    {entry.numberOfCompletions > 1 &&
+                      entry.numberOfCompletions + ' times '}
+                  </>
+                )}
+              </Text>
+              {entry.numberOfCompletions >= 1 && (
+                <CheckIcon
+                  color={
+                    entry.numberOfCompletions === 0
+                      ? colors.stone[400]
+                      : color.base
+                  }
+                  size={12}
+                  strokeWidth={3}
+                />
+              )}
+            </View>
+          </View>
+          <View className="flex flex-row items-center justify-between">
+            <UserImageNameAndUsername data={user} />
+            <ChevronRightIcon
+              color={colorScheme === 'dark' ? colors.white : colors.black}
+            />
+          </View>
+          {entry.note && <Text className="text-base">{entry.note}</Text>}
+          {entry.image && (
+            <Image
+              source={{ uri: entry.image }}
+              className="aspect-square w-full rounded-xl"
+            />
+          )}
+          {/* the user sees a button to modify the entry */}
+          {modifyEntryButton ||
+            // for other users, show nudge button if no completions and it's today
+            (entry.numberOfCompletions === 0 && isToday && (
+              <View className="flex flex-row">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  label="Nudge"
+                  icon={BellIcon}
+                  onPress={() => alert('todo')}
+                />
+              </View>
+            ))}
+        </View>
+      </Pressable>
+    </Link>
+  );
+};

--- a/src/components/habit-card.tsx
+++ b/src/components/habit-card.tsx
@@ -50,7 +50,7 @@ export function HabitCard({ habit }: HabitCardProps) {
     error,
     refetch,
   } = useHabitCompletions({
-    variables: { habitId: habit.id, userId },
+    variables: { habitId: habit.id, userId, numDays: 7 },
   });
 
   return (

--- a/src/components/modify-habit-entry/day-navigation.tsx
+++ b/src/components/modify-habit-entry/day-navigation.tsx
@@ -1,19 +1,18 @@
 import { ArrowLeftIcon, ArrowRightIcon } from 'lucide-react-native';
 import { useColorScheme } from 'nativewind';
 
-import { type HabitCompletionWithDateInfoT } from '@/api';
 import { Pressable, Text, View } from '@/ui';
 
 interface DayNavigationProps {
   selectedDayIndex: number;
-  completions: HabitCompletionWithDateInfoT[];
+  datesList: Date[];
   hasUnsavedChanges: boolean;
   onDayChange: (index: number) => void;
   resetStates: () => void;
 }
 export function DayNavigation({
   selectedDayIndex,
-  completions,
+  datesList,
   hasUnsavedChanges,
   onDayChange,
   resetStates,
@@ -22,55 +21,59 @@ export function DayNavigation({
   return (
     <View className="flex-col gap-2">
       <View className="flex-row items-center justify-center">
-        <Pressable
-          className="rounded-lg border border-slate-200 px-4 py-2 dark:border-stone-700 dark:bg-transparent"
-          onPress={() => {
-            onDayChange(selectedDayIndex - 1);
-            resetStates();
-          }}
-          disabled={selectedDayIndex === 0 || hasUnsavedChanges}
-          style={{
-            opacity: selectedDayIndex === 0 || hasUnsavedChanges ? 0.3 : 1,
-          }}
-        >
-          <ArrowLeftIcon
-            size={16}
-            color={colorScheme === 'dark' ? 'white' : 'black'}
-          />
-        </Pressable>
+        {datesList.length > 1 && (
+          <Pressable
+            className="rounded-lg border border-slate-200 bg-white px-4 py-2 dark:border-stone-700 dark:bg-transparent"
+            onPress={() => {
+              onDayChange(selectedDayIndex - 1);
+              resetStates();
+            }}
+            disabled={selectedDayIndex === 0 || hasUnsavedChanges}
+            style={{
+              opacity: selectedDayIndex === 0 || hasUnsavedChanges ? 0.3 : 1,
+            }}
+          >
+            <ArrowLeftIcon
+              size={16}
+              color={colorScheme === 'dark' ? 'white' : 'black'}
+            />
+          </Pressable>
+        )}
         <Text className="w-32 text-center font-bold">
           {new Date(
-            new Date(completions[selectedDayIndex].date).setDate(
-              new Date(completions[selectedDayIndex].date).getDate() + 1,
+            Date.UTC(
+              datesList[selectedDayIndex].getUTCFullYear(),
+              datesList[selectedDayIndex].getUTCMonth(),
+              datesList[selectedDayIndex].getUTCDate(),
             ),
           ).toLocaleDateString('en-US', {
             weekday: 'short',
             month: 'short',
             day: 'numeric',
+            timeZone: 'UTC',
           })}
         </Text>
-        <Pressable
-          className="rounded-lg border border-slate-200 px-4 py-2 dark:border-stone-700 dark:bg-transparent"
-          onPress={() => onDayChange(selectedDayIndex + 1)}
-          disabled={
-            selectedDayIndex === completions.length - 1 || hasUnsavedChanges
-          }
-          style={{
-            opacity:
-              selectedDayIndex === completions.length - 1 || hasUnsavedChanges
-                ? 0.3
-                : 1,
-          }}
-        >
-          <ArrowRightIcon
-            size={16}
-            color={colorScheme === 'dark' ? 'white' : 'black'}
-          />
-        </Pressable>
+        {datesList.length > 1 && (
+          <Pressable
+            className="rounded-lg border border-slate-200 bg-white px-4 py-2 dark:border-stone-700 dark:bg-transparent"
+            onPress={() => onDayChange(selectedDayIndex + 1)}
+            disabled={
+              selectedDayIndex === datesList.length - 1 || hasUnsavedChanges
+            }
+            style={{
+              opacity:
+                selectedDayIndex === datesList.length - 1 || hasUnsavedChanges
+                  ? 0.3
+                  : 1,
+            }}
+          >
+            <ArrowRightIcon
+              size={16}
+              color={colorScheme === 'dark' ? 'white' : 'black'}
+            />
+          </Pressable>
+        )}
       </View>
-      <Text className="text-center text-sm text-orange-500 dark:text-orange-500">
-        {hasUnsavedChanges ? 'You have unsaved changes' : ' '}
-      </Text>
     </View>
   );
 }

--- a/src/components/modify-habit-entry/index.tsx
+++ b/src/components/modify-habit-entry/index.tsx
@@ -3,17 +3,19 @@ import { PenIcon } from 'lucide-react-native';
 import React, { useState } from 'react';
 
 import { type HabitCompletionWithDateInfoT, type HabitT } from '@/api';
-import { Pressable, Text, useModal, View } from '@/ui';
+import { Button, Pressable, Text, useModal, View } from '@/ui';
 
 import { ModifyEntryModal } from './modify-entry-modal';
 
 export interface ModifyEntryProps {
   habit: HabitT;
   completions: HabitCompletionWithDateInfoT[];
+  showAsNormalButton?: boolean;
 }
 export default function ModifyHabitEntry({
   habit,
   completions,
+  showAsNormalButton = false,
 }: ModifyEntryProps) {
   const modal = useModal();
   const [selectedDayIndex, setSelectedDayIndex] = useState<number>(
@@ -22,17 +24,27 @@ export default function ModifyHabitEntry({
 
   return (
     <>
-      <View className="flex flex-row justify-end">
-        <Pressable
-          className="flex flex-row items-center gap-2 rounded-full border px-4 py-1"
-          style={{ borderColor: habit.color.text }}
-          onPress={modal.present}
-        >
-          <PenIcon size={16} color={habit.color.text} />
-          <Text className="" style={{ color: habit.color.text }}>
-            Modify entry or add note/image
-          </Text>
-        </Pressable>
+      <View className="flex flex-row">
+        {showAsNormalButton ? (
+          <Button
+            variant="outline"
+            size="sm"
+            label="Modify entry or add note/image"
+            icon={PenIcon}
+            onPress={modal.present}
+          />
+        ) : (
+          <Pressable
+            className="flex flex-row items-center gap-2 rounded-full border px-4 py-1"
+            style={{ borderColor: habit.color.text }}
+            onPress={modal.present}
+          >
+            <PenIcon size={16} color={habit.color.text} />
+            <Text className="" style={{ color: habit.color.text }}>
+              Modify entry or add note/image
+            </Text>
+          </Pressable>
+        )}
       </View>
 
       <ModifyEntryModal

--- a/src/components/modify-habit-entry/modify-entry-modal.tsx
+++ b/src/components/modify-habit-entry/modify-entry-modal.tsx
@@ -12,7 +12,7 @@ import {
   type UserIdT,
 } from '@/api';
 import { useModifyHabitEntry } from '@/api/habits/use-modify-entry';
-import { colors, Header, Modal, type ModalMethods, View } from '@/ui';
+import { colors, Header, Modal, type ModalMethods, Text, View } from '@/ui';
 
 import { CompletionsSection } from './completions-section';
 import { DayNavigation } from './day-navigation';
@@ -128,13 +128,20 @@ export function ModifyEntryModal({
           rightButton={{ icon: SaveIcon, text: 'Save', onPress: handleSave }}
         />
         <View className="flex flex-col gap-4">
-          <DayNavigation
-            selectedDayIndex={selectedDayIndex}
-            completions={completions}
-            hasUnsavedChanges={hasUnsavedChanges()}
-            onDayChange={setSelectedDayIndex}
-            resetStates={resetStates}
-          />
+          <View className="-mb-2 flex flex-col">
+            <DayNavigation
+              selectedDayIndex={selectedDayIndex}
+              datesList={completions.map(
+                (completion) => new Date(completion.date),
+              )}
+              hasUnsavedChanges={hasUnsavedChanges()}
+              onDayChange={setSelectedDayIndex}
+              resetStates={resetStates}
+            />
+            <Text className="text-center text-sm text-orange-500 dark:text-orange-500">
+              {hasUnsavedChanges() ? 'You have unsaved changes' : ' '}
+            </Text>
+          </View>
           <CompletionsSection
             numberOfCompletions={numberOfCompletions}
             setNumberOfCompletions={setNumberOfCompletions}

--- a/src/components/user-card.tsx
+++ b/src/components/user-card.tsx
@@ -18,15 +18,23 @@ export default function UserCard({ data }: { data: UserT }) {
       }}
       asChild
     >
-      <Pressable className="my-1 flex flex-row gap-2 rounded-3xl border border-stone-200 bg-white px-4 py-[10px] dark:border-stone-700 dark:bg-transparent">
-        <UserPicture userId={data.id} size={40} />
-        <View className="flex flex-col">
-          <Text className="text-base font-semibold">{data.displayName}</Text>
-          <Text className="text-xs font-medium text-stone-400 dark:text-stone-400">
-            @{data.username}
-          </Text>
-        </View>
+      <Pressable className="my-1 rounded-3xl border border-stone-200 bg-white px-4 py-[10px] dark:border-stone-700 dark:bg-transparent">
+        <UserImageNameAndUsername data={data} />
       </Pressable>
     </Link>
+  );
+}
+
+export function UserImageNameAndUsername({ data }: { data: UserT }) {
+  return (
+    <View className="flex flex-row gap-2">
+      <UserPicture userId={data.id} size={40} />
+      <View className="flex flex-col">
+        <Text className="text-base font-semibold">{data.displayName}</Text>
+        <Text className="text-xs font-medium text-stone-400 dark:text-stone-400">
+          @{data.username}
+        </Text>
+      </View>
+    </View>
   );
 }


### PR DESCRIPTION
### TL;DR

Added a detailed habit view screen showing all participants' completions and activity history.

https://github.com/user-attachments/assets/2ee66d75-c7c2-4e72-868f-a1899be457a8

### What changed?

- Created a new habit view screen with participant activity feed
- Added support for viewing historical habit completions across all dates
- Implemented day navigation to browse through completion history
- Added ability to modify entries, add notes, and view images
- Created new hooks for fetching all users' habit completions
- Added UI components for displaying user entries and completion status

### How to test?

1. Navigate to a habit from the habits list
2. Verify the habit details and participant list are displayed
3. Use day navigation to browse through different dates
4. Test modifying your own entries using the modify button
5. Verify other participants' entries and completion status are shown
6. Check that the nudge button appears for incomplete entries on the current day