### PR TITLE
feat: add habit participant management UI

### DIFF
--- a/src/api/habits/mock-habits.tsx
+++ b/src/api/habits/mock-habits.tsx
@@ -88,6 +88,11 @@ export const mockHabits: { id: HabitIdT; data: DbHabitT }[] = [
           displayName: 'John Doe',
           username: 'john_doe',
           lastActivity: new Date('2024-12-01T00:00:00'),
+        },
+        ['6' as UserIdT]: {
+          displayName: 'Sarah Wilson',
+          username: 'sarah_wilson',
+          lastActivity: new Date('2024-12-15T00:00:00'),
           isOwner: true,
         },
       },
@@ -159,6 +164,13 @@ export const mockHabitCompletions: Record<HabitIdT, AllCompletionsT> = {
         '2024-12-04': { numberOfCompletions: 0 },
         '2024-12-05': { numberOfCompletions: 0 },
         '2024-12-06': { numberOfCompletions: 1 },
+      },
+    },
+    ['6' as UserIdT]: {
+      entries: {
+        '2024-12-13': { numberOfCompletions: 1 },
+        '2024-12-14': { numberOfCompletions: 1 },
+        '2024-12-15': { numberOfCompletions: 1, note: 'Great book tonight!' },
       },
     },
   },

--- a/src/api/users/mock-users.tsx
+++ b/src/api/users/mock-users.tsx
@@ -31,6 +31,12 @@ export const mockUsers: UserT[] = [
     username: 'lorem_ipsum',
     createdAt: new Date(),
   },
+  {
+    id: '6' as UserIdT,
+    displayName: 'Sarah Wilson',
+    username: 'sarah_wilson',
+    createdAt: new Date(),
+  },
 ];
 
 export const mockPictures: Record<UserIdT, string> = {
@@ -39,6 +45,7 @@ export const mockPictures: Record<UserIdT, string> = {
   ['3' as UserIdT]: 'https://randomuser.me/api/portraits/women/4.jpg',
   ['4' as UserIdT]: 'https://randomuser.me/api/portraits/men/5.jpg',
   ['5' as UserIdT]: 'https://randomuser.me/api/portraits/men/6.jpg',
+  ['6' as UserIdT]: 'https://randomuser.me/api/portraits/women/7.jpg',
 };
 
 export const mockRelationships: Record<

--- a/src/components/modify-habit-entry/index.tsx
+++ b/src/components/modify-habit-entry/index.tsx
@@ -24,7 +24,7 @@ export default function ModifyHabitEntry({
 
   return (
     <>
-      <View className="flex flex-row">
+      <View className="flex flex-row justify-end">
         {showAsNormalButton ? (
           <Button
             variant="outline"

--- a/src/components/user-card.tsx
+++ b/src/components/user-card.tsx
@@ -1,11 +1,38 @@
 import { Link } from 'expo-router';
+import { EllipsisIcon } from 'lucide-react-native';
+import { useColorScheme } from 'nativewind';
 
 import { type UserT } from '@/api';
-import { Pressable, Text, View } from '@/ui';
+import { colors, Pressable, Text, View } from '@/ui';
+import {
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuItemTitle,
+  DropdownMenuRoot,
+  DropdownMenuTrigger,
+} from '@/ui/dropdown-menu';
 
 import UserPicture from './picture';
 
-export default function UserCard({ data }: { data: UserT }) {
+interface UserCardProps {
+  data: UserT;
+  showOwnerBadge?: boolean;
+  showManageOptions?: boolean;
+  onTransferOwnership?: () => void;
+  onKickUser?: () => void;
+  onPress?: () => void;
+}
+
+export default function UserCard({
+  data,
+  showOwnerBadge,
+  showManageOptions,
+  onTransferOwnership,
+  onKickUser,
+  onPress,
+}: UserCardProps) {
+  const { colorScheme } = useColorScheme();
+
   return (
     <Link
       push
@@ -18,8 +45,46 @@ export default function UserCard({ data }: { data: UserT }) {
       }}
       asChild
     >
-      <Pressable className="my-1 rounded-3xl border border-stone-200 bg-white px-4 py-[10px] dark:border-stone-700 dark:bg-transparent">
+      <Pressable
+        className="my-1 flex-row items-center justify-between rounded-3xl border border-stone-200 bg-white px-4 py-[10px] dark:border-stone-700 dark:bg-transparent"
+        onPress={() => onPress?.()}
+      >
         <UserImageNameAndUsername data={data} />
+        {showOwnerBadge && (
+          <Text className="text-xs text-stone-400 dark:text-stone-500">
+            Admin
+          </Text>
+        )}
+        {showManageOptions && (
+          <DropdownMenuRoot>
+            <DropdownMenuTrigger>
+              <Pressable>
+                <EllipsisIcon
+                  size={24}
+                  color={colorScheme === 'dark' ? colors.white : colors.black}
+                />
+              </Pressable>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent>
+              <DropdownMenuItem
+                key={'transfer'}
+                onSelect={onTransferOwnership}
+                destructive
+              >
+                <DropdownMenuItemTitle>
+                  Transfer ownership
+                </DropdownMenuItemTitle>
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                key={'remove'}
+                onSelect={onKickUser}
+                destructive
+              >
+                <DropdownMenuItemTitle>Remove from habit</DropdownMenuItemTitle>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenuRoot>
+        )}
       </Pressable>
     </Link>
   );

--- a/src/ui/button.tsx
+++ b/src/ui/button.tsx
@@ -34,7 +34,7 @@ const button = tv({
       },
       destructive: {
         container:
-          'border border-red-200 bg-white dark:border-red-500 dark:bg-transparent',
+          'border border-red-200 bg-white dark:border-red-500 dark:bg-red-500/5',
         label: 'font-medium text-red-500',
         indicator: 'text-red-500',
       },


### PR DESCRIPTION
### TL;DR
Added user management features to habit view, including ownership transfer and participant removal capabilities.

https://github.com/user-attachments/assets/cafe2236-08f5-49e0-b281-4c73d559ff4b

### What changed?
- Enhanced the habit view modal with detailed habit information display
- Added participant management features including ownership transfer and user removal
- Updated the UserCard component to support admin badges and management options
- Improved the destructive button styling for dark mode
- Added participant list display with admin controls

### How to test?
1. Open a habit with multiple participants
2. Verify the admin badge appears for the habit owner
3. Check that non-admin participants show management options (ellipsis menu)
4. Test the ownership transfer and kick user options from the ellipsis menu
5. Verify the updated destructive button styling in dark mode
6. Confirm the new mock user "Sarah Wilson" appears in relevant habit data